### PR TITLE
Ref line used for masking - fixed counting in range

### DIFF
--- a/scripts/processing_spec.py
+++ b/scripts/processing_spec.py
@@ -156,7 +156,8 @@ def process_spectra(source_list,
 
             # combine masks of all priors if more than one line is used
             if n_mask>0:
-                for n_mask_i in range(1,n_mask):
+                # for n_mask_i in range(1,n_mask): 
+                for n_mask_i in range(1,n_mask+1):  
                     line_i = lines_data["line_name"][n_mask_i].upper()
                     mask_i, _, _ = construct_mask(line_i, this_data, SN_processing)
                     this_data["SPEC_MASK_"+line_i]= Column(mask_i, unit=au.dimensionless_unscaled, description=f'Velocity-integration mask for {line_i}')


### PR DESCRIPTION
This was fixed in the previous version but got lost in the newest version. 

Issue: When selecting several lines as priors (i.e., using 'ref_line = 1' for two priors) for the mom map creation only the first one was used. This fix makes sure both are used.