### PR TITLE
Add new optional feature: fixed velocity window

### DIFF
--- a/PyStructure.conf
+++ b/PyStructure.conf
@@ -66,8 +66,9 @@ ref_line = 'first'
 SN_processing = [2,4]
 strict_mask = False
 
-# define whether input mask should be used for processing line cubes
+# define whether input mask or fixed velocity window should be used for processing line cubes (defined in step 6)
 use_input_mask = False
+use_fixed_vel_mask = False
 
 # define whether masking should be adjusted to hyperfine structure lines
 # <filename of hyperfine structure file>
@@ -142,4 +143,18 @@ spire250,	SPIRE250,	MJy/sr,	_spire250_gauss21.fits,	./data/
 # Column 2: description for database
 # Column 3: extension
 # Column 4: path to files
+
+## PPV velocity mask as fits file
+# Column 1: short name of mask
+# Column 2: description for database
+# Column 3: extension
+# Column 4: path to files
 # mask, input_mask, _co21_mask.fits,	data/
+
+## Fixed velocity window
+# Column 1: short name of mask
+# Column 2: description for database
+# Column 3: window start
+# Column 4: window end
+# Column 5: velocity unit
+# mask, fixed_velocity_window, -100, 100, km/s

--- a/create_database.py
+++ b/create_database.py
@@ -273,8 +273,10 @@ def create_database(just_source=None, quiet=False, conf=False):
         print(f'{"[INFO]":<10}', f'Loading {n_cubes} cube(s): {cube_names}.')
 
     # Add the input velocity-integration mask to the structure
-    # mask_columns = ["mask_name", "mask_desc", "mask_unit", "mask_ext", "mask_dir"]
-    mask_columns = ["mask_name", "mask_desc", "mask_ext", "mask_dir"]
+    if use_fixed_vel_mask:
+        mask_columns = ["mask_name", "mask_desc", "mask_start", "mask_end", "mask_unit"]
+    else:
+        mask_columns = ["mask_name", "mask_desc", "mask_ext", "mask_dir"]
     input_mask = pd.read_csv(mask_file, names = mask_columns, sep=r'[,\s]{2,20}', comment="#")
     if len(input_mask) == 0:
         if quiet == False:
@@ -283,6 +285,8 @@ def create_database(just_source=None, quiet=False, conf=False):
         if quiet == False:
             if use_input_mask:
                 print(f'{"[INFO]":<10}', f'Input mask loaded into structure; will be used for products.')
+            elif use_fixed_vel_mask:
+                print(f'{"[INFO]":<10}', f'Fixed velocity window mask loaded into structure; will be used for products.')
             else:
                 print(f'{"[INFO]":<10}', f'Input mask loaded into structure; will NOT be used for products.')
 
@@ -698,24 +702,47 @@ def create_database(just_source=None, quiet=False, conf=False):
         #---------------------------------------------------------------------
 
         if len(input_mask) > 0:
-            # assign mask file
-            this_mask_file = input_mask["mask_dir"][0] + this_source + input_mask["mask_ext"][0]
 
-            # print commands
-            if not path.exists(this_mask_file):
-                print(f'{"[ERROR]":<10}', f'Mask not found for {this_source}.')
-                continue
-            print(f'{"[INFO]":<10}', f'Sampling mask for {this_source}.')
-        
-            # sample mask
-            this_spec, this_hdr = sample_mask(in_data = this_mask_file,
-                                            ra_samp = samp_ra,
-                                            dec_samp = samp_dec,
-                                            target_hdr = ov_hdr)
+            if use_fixed_vel_mask:
+                # get velocity window from config file
+                mask_unit = input_mask["mask_unit"][0]
+                mask_start = input_mask["mask_start"][0] * au.Unit(mask_unit)
+                mask_end = input_mask["mask_end"][0] * au.Unit(mask_unit)
+
+                # print commands
+                print(f'{"[INFO]":<10}', f'Building fixed velocity mask for {this_source}: {mask_start} to {mask_end}.')
+
+                # get velocity axis
+                v0 = this_data.meta["SPEC_VCHAN0"]  # reference velocity
+                deltav = this_data.meta["SPEC_DELTAV"]  # velocity channel width
+                crpix = this_data.meta["SPEC_CRPIX"]  # reference pixel/channel
+                vaxis = v0 + (np.arange(n_chan)-(crpix-1))*deltav  # velocity axis
+                vaxis = vaxis.to(au.Unit(mask_unit))  # convert to unit of mask
+
+                # sample fixed velocity window to database grid
+                this_spec = np.zeros((n_pts, n_chan))
+                mask_vel = (vaxis >= mask_start) & (vaxis <= mask_end)  # create boolean mask for velocity channels within the specified window
+                this_spec[:, mask_vel] = 1  # set values inside fixed velocity window to 1 (True)
+
+            else:
+                # assign mask file
+                this_mask_file = input_mask["mask_dir"][0] + this_source + input_mask["mask_ext"][0]
+
+                # print commands
+                if not path.exists(this_mask_file):
+                    print(f'{"[ERROR]":<10}', f'Mask not found for {this_source}.')
+                    continue
+                print(f'{"[INFO]":<10}', f'Sampling mask for {this_source}.')
+            
+                # sample mask
+                this_spec, this_hdr = sample_mask(in_data = this_mask_file,
+                                                  ra_samp = samp_ra,
+                                                  dec_samp = samp_dec,
+                                                  target_hdr = ov_hdr)
 
             # add to database
             this_tag_name = 'SPEC_'+input_mask["mask_name"][0].upper()
-            this_data[this_tag_name] = Column(this_spec ,unit= au.dimensionless_unscaled, description='User-provided velocity-integration mask (used for integrated products)')
+            this_data[this_tag_name] = Column(this_spec, unit= au.dimensionless_unscaled, description=input_mask["mask_desc"][0])
             
 
             sz_this_spec = np.shape(this_spec)
@@ -736,11 +763,18 @@ def create_database(just_source=None, quiet=False, conf=False):
     #---------------------------------------------------------------------
     if not quiet:
         print('-------------------------------')
-        if use_input_mask:
+        if use_fixed_vel_mask:
+            print(f'{"[INFO]":<10}', f'Start processing spectra for {this_source}; using fixed velocity window.')
+        elif use_input_mask:
             print(f'{"[INFO]":<10}', f'Start processing spectra for {this_source}; using input mask.')
         else:
             print(f'{"[INFO]":<10}', f'Start processing spectra for {this_source}.')
      
+    if use_fixed_vel_mask | use_input_mask:
+        use_mask = True
+    else:
+        use_mask = False
+
     process_spectra(source_list,
                     cubes,
                     fnames,
@@ -750,7 +784,7 @@ def create_database(just_source=None, quiet=False, conf=False):
                     SN_processing,
                     strict_mask,
                     input_mask, 
-                    use_input_mask, 
+                    use_mask, 
                     hfs_data,
                     use_hfs_lines,
                     [mom_thresh,conseq_channels,mom2_method],


### PR DESCRIPTION
This is small feature update which adds the option to compute the moments over a fixed velocity window. It does not affect any other part of the pipeline. There are two new lines in the config file:
1. a new keyword to trigger the usage of a fixed velocity window
2. an (optional) new line in step 6 (mask) to set the velocity range over which to compute the moments
