### PR TITLE
New optional feature: velocity range(s) to compute noise

### DIFF
--- a/PyStructure.conf
+++ b/PyStructure.conf
@@ -70,6 +70,13 @@ strict_mask = False
 use_input_mask = False
 use_fixed_vel_mask = False
 
+# (only relevant when use_fixed_vel_mask = True)
+# Set to True to define one or more explicit noise velocity ranges in Step 6.
+# Those ranges are used for the per-channel RMS estimation and its propagation
+# into the moment maps, instead of the default behaviour of using all off-signal
+# (mask == 0) channels.
+use_noise_vel_ranges = False
+
 # define whether masking should be adjusted to hyperfine structure lines
 # <filename of hyperfine structure file>
 # hfs_file = 'List_Files/hfs_lines.txt' # for usage: uncomment and set use_hfs_lines to True
@@ -158,3 +165,18 @@ spire250,	SPIRE250,	MJy/sr,	_spire250_gauss21.fits,	./data/
 # Column 4: window end
 # Column 5: velocity unit
 # mask, fixed_velocity_window, -100, 100, km/s
+
+## Noise velocity range(s) for RMS estimation (only used when use_noise_vel_ranges = True)
+# Add one or more lines below the fixed velocity window line.  Each line defines a
+# velocity window over which the noise (RMS) is measured.  Multiple ranges are
+# combined (OR logic) into a single noise mask that is applied per spatial point.
+# The same five-column format as the signal window is used:
+# Column 1: any short label (e.g. noise_vel)
+# Column 2: description (arbitrary)
+# Column 3: window start (same unit as Column 5)
+# Column 4: window end   (same unit as Column 5)
+# Column 5: velocity unit (must be consistent with the signal mask unit above)
+#
+# Example – two noise windows flanking the signal:
+# noise_vel, noise_range_blue, -300, -150, km/s
+# noise_vel, noise_range_red,   150,  300, km/s

--- a/create_database.py
+++ b/create_database.py
@@ -277,7 +277,20 @@ def create_database(just_source=None, quiet=False, conf=False):
         mask_columns = ["mask_name", "mask_desc", "mask_start", "mask_end", "mask_unit"]
     else:
         mask_columns = ["mask_name", "mask_desc", "mask_ext", "mask_dir"]
-    input_mask = pd.read_csv(mask_file, names = mask_columns, sep=r'[,\s]{2,20}', comment="#")
+    input_mask_all = pd.read_csv(mask_file, names = mask_columns, sep=r'[,\s]{2,20}', comment="#")
+
+    # When use_fixed_vel_mask is True, separate signal mask rows (row 0) from
+    # optional noise velocity range rows (subsequent rows tagged 'noise_vel').
+    if use_fixed_vel_mask and len(input_mask_all) > 0:
+        input_mask = input_mask_all.iloc[[0]].reset_index(drop=True)
+        if 'use_noise_vel_ranges' in globals() and use_noise_vel_ranges:
+            noise_vel_ranges = input_mask_all.iloc[1:].reset_index(drop=True)
+        else:
+            noise_vel_ranges = pd.DataFrame()
+    else:
+        input_mask = input_mask_all
+        noise_vel_ranges = pd.DataFrame()
+
     if len(input_mask) == 0:
         if quiet == False:
             print(f'{"[INFO]":<10}', f'No mask provided; will be constructed from prior line(s).')
@@ -287,6 +300,8 @@ def create_database(just_source=None, quiet=False, conf=False):
                 print(f'{"[INFO]":<10}', f'Input mask loaded into structure; will be used for products.')
             elif use_fixed_vel_mask:
                 print(f'{"[INFO]":<10}', f'Fixed velocity window mask loaded into structure; will be used for products.')
+                if len(noise_vel_ranges) > 0:
+                    print(f'{"[INFO]":<10}', f'{len(noise_vel_ranges)} noise velocity range(s) loaded; will be used for RMS estimation.')
             else:
                 print(f'{"[INFO]":<10}', f'Input mask loaded into structure; will NOT be used for products.')
 
@@ -724,6 +739,21 @@ def create_database(just_source=None, quiet=False, conf=False):
                 mask_vel = (vaxis >= mask_start) & (vaxis <= mask_end)  # create boolean mask for velocity channels within the specified window
                 this_spec[:, mask_vel] = 1  # set values inside fixed velocity window to 1 (True)
 
+                # build noise mask from additional noise velocity range(s) if provided
+                if 'use_noise_vel_ranges' in globals() and use_noise_vel_ranges and len(noise_vel_ranges) > 0:
+                    noise_spec = np.zeros((n_pts, n_chan))
+                    for _, noise_row in noise_vel_ranges.iterrows():
+                        noise_unit = noise_row["mask_unit"]
+                        noise_start = float(noise_row["mask_start"]) * au.Unit(noise_unit)
+                        noise_end   = float(noise_row["mask_end"])   * au.Unit(noise_unit)
+                        vaxis_noise = vaxis.to(au.Unit(noise_unit))
+                        noise_chan = (vaxis_noise >= noise_start) & (vaxis_noise <= noise_end)
+                        noise_spec[:, noise_chan] = 1
+                        print(f'{"[INFO]":<10}', f'Adding noise velocity range: {noise_start} to {noise_end}.')
+                    # store noise mask in the database
+                    this_data['SPEC_NOISE_MASK'] = Column(noise_spec, unit=au.dimensionless_unscaled,
+                                                          description='Noise velocity window mask (channels used for RMS estimation)')
+
             else:
                 # assign mask file
                 this_mask_file = input_mask["mask_dir"][0] + this_source + input_mask["mask_ext"][0]
@@ -775,6 +805,8 @@ def create_database(just_source=None, quiet=False, conf=False):
     else:
         use_mask = False
 
+    _use_noise_vel_ranges = 'use_noise_vel_ranges' in globals() and use_noise_vel_ranges and use_fixed_vel_mask
+
     process_spectra(source_list,
                     cubes,
                     fnames,
@@ -788,6 +820,7 @@ def create_database(just_source=None, quiet=False, conf=False):
                     hfs_data,
                     use_hfs_lines,
                     [mom_thresh,conseq_channels,mom2_method],
+                    use_noise_vel_ranges=_use_noise_vel_ranges,
                     )
   
     if save_mom_maps | save_band_maps:

--- a/scripts/mom_computer.py
+++ b/scripts/mom_computer.py
@@ -1,8 +1,20 @@
 import numpy as np
 
-def get_mom_maps(spec_cube, mask, vaxis, mom_calc =[3, 3,"fwhm"]):
+def get_mom_maps(spec_cube, mask, vaxis, mom_calc=[3, 3, "fwhm"], noise_mask=None):
     """
-    Function to compute moment maps
+    Function to compute moment maps.
+
+    :param spec_cube: 2D array (n_pts, n_chan) of spectral data with astropy units.
+    :param mask: 2D array (n_pts, n_chan) velocity-integration mask (1 = signal channels).
+    :param vaxis: 1D velocity axis array with astropy units.
+    :param mom_calc: list [SNthresh, conseq_channels, mom2_method].
+    :param noise_mask: optional 2D boolean/int array (n_pts, n_chan) or 1D (n_chan,) boolean
+                       array marking channels to use for RMS estimation.  When provided,
+                       the RMS is computed from those channels only (instead of all
+                       off-signal channels, i.e. mask==0).  A 1D array is broadcast
+                       across all spatial points.  If None (default), the original
+                       behaviour is preserved: RMS is estimated from all channels where
+                       mask==0 and spectrum!=0.
     """
 
     # --- strip units ONCE ---
@@ -11,6 +23,20 @@ def get_mom_maps(spec_cube, mask, vaxis, mom_calc =[3, 3,"fwhm"]):
     dv        = abs(v_vals[0] - v_vals[1])      # scalar
     spec_unit = spec_cube.unit
     v_unit    = vaxis.unit
+
+    # --- pre-process noise_mask ---
+    if noise_mask is not None:
+        # strip astropy units if present
+        if hasattr(noise_mask, 'value'):
+            noise_mask_vals = noise_mask.value
+        else:
+            noise_mask_vals = np.asarray(noise_mask)
+        # broadcast 1D mask to 2D (n_pts, n_chan)
+        if noise_mask_vals.ndim == 1:
+            noise_mask_vals = np.broadcast_to(noise_mask_vals, spec_vals.shape)
+        noise_mask_vals = noise_mask_vals.astype(bool)
+    else:
+        noise_mask_vals = None
 
     # --- set up output maps WITH units ---
     mom_maps = {}
@@ -54,7 +80,14 @@ def get_mom_maps(spec_cube, mask, vaxis, mom_calc =[3, 3,"fwhm"]):
             continue
 
         # ---------------- RMS ----------------
-        rms = np.nanstd(spectrum[np.logical_and(mask_m == 0, spectrum != 0)])
+        if noise_mask_vals is not None:
+            # Use the explicitly defined noise velocity window(s)
+            noise_sel = noise_mask_vals[m]
+            rms_data = spectrum[np.logical_and(noise_sel, spectrum != 0)]
+        else:
+            # Default: use all off-signal (mask==0) channels
+            rms_data = spectrum[np.logical_and(mask_m == 0, spectrum != 0)]
+        rms = np.nanstd(rms_data) if len(rms_data) > 0 else np.nan
         mom_maps["rms"][m] = rms * spec_unit
 
         # ---------------- Tpeak ----------------

--- a/scripts/processing_spec.py
+++ b/scripts/processing_spec.py
@@ -82,10 +82,15 @@ def process_spectra(source_list,
                     hfs_data = None,
                     use_hfs_lines = False,
                     mom_calc = [3, 3, "fwhm"],
-                    just_source = None
+                    just_source = None,
+                    use_noise_vel_ranges = False,
                     ):
     """
-    :param lines_data:   Pandas DataFrame which is the cubes_list.txt
+    :param lines_data:        Pandas DataFrame which is the cubes_list.txt.
+    :param use_noise_vel_ranges: If True, read the SPEC_NOISE_MASK column from the
+                                 database and pass it to get_mom_maps so that the RMS
+                                 is estimated only over the explicitly defined noise
+                                 velocity window(s) rather than all off-signal channels.
     """
     
     n_sources = len(source_list)
@@ -317,6 +322,14 @@ def process_spectra(source_list,
         print(f'{"[INFO]":<10}', 'Done with mask. Computing moments.')
 
         #-------------------------------------------------------------------
+        # Load noise mask (if noise velocity ranges were specified)
+        #-------------------------------------------------------------------
+        noise_mask = None
+        if use_noise_vel_ranges and 'SPEC_NOISE_MASK' in this_data.keys():
+            noise_mask = this_data['SPEC_NOISE_MASK']
+            print(f'{"[INFO]":<10}', 'Using explicit noise velocity window(s) for RMS estimation.')
+
+        #-------------------------------------------------------------------
         # Apply the mask to all lines and shuffle them
         #-------------------------------------------------------------------
         n_chan_new = 200 # LN: not used (remove?)
@@ -354,11 +367,11 @@ def process_spectra(source_list,
             if use_hfs_lines:
                 if line_name in lines_hfs:
                     mask_hfs = this_data[f'SPEC_MASK_{line_name.upper()}']* au.Unit(1)
-                    mom_maps = get_mom_maps(this_spec, mask_hfs, this_vaxis, mom_calc)
+                    mom_maps = get_mom_maps(this_spec, mask_hfs, this_vaxis, mom_calc, noise_mask=noise_mask)
                 else:
-                    mom_maps = get_mom_maps(this_spec, mask, this_vaxis, mom_calc)
+                    mom_maps = get_mom_maps(this_spec, mask, this_vaxis, mom_calc, noise_mask=noise_mask)
             else:
-                mom_maps = get_mom_maps(this_spec, mask, this_vaxis, mom_calc)
+                mom_maps = get_mom_maps(this_spec, mask, this_vaxis, mom_calc, noise_mask=noise_mask)
 
             # Save in structure
             line_desc = lines_data["line_desc"][jj]


### PR DESCRIPTION
This is a feature update for the optional feature of using a fixed velocity window. Currently, the noise is simply computed from the inverse of the ppv mask, which could include plenty of emission, if the fixed velocity window is only selecting one component of interest.

This new feature now enables to add a velocity range (or several ranges) to the config file, to specify the velocity range over which the noise should be computed.

This update has no effect on the remaining pipeline.