### PR TITLE
Update masking (new options to combine pipeline and input masks)

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -72,7 +72,7 @@ folder_savefits = ./saved_fits_files/
 #
 # MASK TABLE (after "# ---- mask ----")
 #   For file mask  : name, description, file_extension, directory
-#   For fixed-vel  : name, description, start_vel, end_vel, unit
+#   For window-vel  : name, description, start_vel, end_vel, unit
 #   (leave section empty if no external mask is used)
 
 [targets]
@@ -96,7 +96,7 @@ spire250,  SPIRE 250 um,      MJy/sr,  _spire250_gauss21.fits,  data/
 # Example file mask (comment out if unused):
 # co_mask, CO signal mask, _co_mask.fits, data/
 #
-# Example fixed-velocity mask (comment out if unused):
+# Example fixed velocity window mask (comment out if unused):
 #vel_mask, Fixed velocity window, -100, 100, km/s
 
 # Example noise velocity windows (comment out if unused):
@@ -143,12 +143,12 @@ CDELT_SHUFF = 4000.0
 # Combination tokens (comma-separated, append to any keyword above):
 #   AND(input)   - AND-combine the ref_line mask with the input mask
 #   OR(input)    - OR-combine the ref_line mask with the input mask
-#   AND(fixed)   - AND-combine the ref_line mask with the fixed velocity mask
-#   OR(fixed)    - OR-combine the ref_line mask with the fixed velocity mask
+#   AND(window)  - AND-combine the ref_line mask with the fixed velocity window
+#   OR(window)   - OR-combine the ref_line mask with the fixed velocity window
 #
 # Examples:
 #   ref_line = 12co21, AND(input)     -> 12co21 S/N mask AND input mask
-#   ref_line = first, OR(fixed)       -> first-line mask OR fixed window
+#   ref_line = first, OR(window)       -> first-line mask OR fixed window
 #   ref_line = all, AND(input)
 ref_line = first
 
@@ -162,7 +162,7 @@ strict_mask = false
 use_input_mask = false
 
 # Use a fixed velocity window defined in the [mask] table above
-use_fixed_vel_mask = false
+use_fixed_window = false
 
 # Use explicit velocity windows (noise_mask rows in the [mask] table) for
 # noise (RMS) estimation instead of using channels outside the signal mask.

--- a/config.txt
+++ b/config.txt
@@ -135,11 +135,22 @@ CDELT_SHUFF = 4000.0
 [masking]
 # Reference line for mask construction:
 #   first        - use the first line in the cube list above
-#   <LINE_NAME>  - use that specific line
+#   <LINE_NAME>  - use that specific line (case-insensitive)
 #   all          - use all lines
 #   n            - use first n lines
-#   individual   - use individual mask per line
-ref_line         = first
+#   individual   - compute one mask per line and apply individually
+#
+# Combination tokens (comma-separated, append to any keyword above):
+#   AND(input)   - AND-combine the ref_line mask with the input mask
+#   OR(input)    - OR-combine the ref_line mask with the input mask
+#   AND(fixed)   - AND-combine the ref_line mask with the fixed velocity mask
+#   OR(fixed)    - OR-combine the ref_line mask with the fixed velocity mask
+#
+# Examples:
+#   ref_line = 12co21, AND(input)     -> 12co21 S/N mask AND input mask
+#   ref_line = first, OR(fixed)       -> first-line mask OR fixed window
+#   ref_line = all, AND(input)
+ref_line = first
 
 # Signal-to-noise thresholds for the two-step mask: [low, high]
 SN_processing = 2, 4
@@ -147,7 +158,7 @@ SN_processing = 2, 4
 # If true, apply a strict spatial consistency check on the mask
 strict_mask = false
 
-# Use an external mask FITS file defined in the [mask] table above
+# Use an external mask FITS file defined in the [mask] table above.
 use_input_mask = false
 
 # Use a fixed velocity window defined in the [mask] table above

--- a/hexmaps/handler_keys.py
+++ b/hexmaps/handler_keys.py
@@ -146,7 +146,7 @@ class KeyHandler:
 
         [resolution]/[masking]/[spectral]/[output]/[structure] are parsed
         before the [targets]/maps/cubes/mask tables so that masking flags
-        (use_fixed_vel_mask etc.) are available when parsing the mask table.
+        (use_fixed_window etc.) are available when parsing the mask table.
         _resolve_resolution runs last because it needs both overlay_file
         (set by _load_targets_and_tables) and target distances (set by
         _load_target_definitions).
@@ -354,7 +354,7 @@ class KeyHandler:
         SN_processing     : list  — [low_SN, high_SN] thresholds
         strict_mask       : bool  — apply spatial connectivity filter
         use_input_mask    : bool  — use an external FITS mask from the [mask] table
-        use_fixed_vel_mask: bool  — use a fixed velocity-window mask
+        use_fixed_window: bool  — use a fixed velocity-window mask
         use_fixed_noise_mask: bool — use explicit velocity windows for noise estimation
         use_hfs_lines     : bool  — apply HFS correction (requires hfs_file)
         fov_erosion_beams : float — FOV erosion in units of the beam FWHM (default 0.5);
@@ -429,8 +429,8 @@ class KeyHandler:
         self.meta["use_input_mask"] = (
             _get("masking", "use_input_mask", "false").lower() == "true"
         )
-        self.meta["use_fixed_vel_mask"] = (
-            _get("masking", "use_fixed_vel_mask", "false").lower() == "true"
+        self.meta["use_fixed_window"] = (
+            _get("masking", "use_fixed_window", "false").lower() == "true"
         )
         self.meta["use_fixed_noise_mask"] = (
             _get("masking", "use_fixed_noise_mask", "false").lower() == "true"
@@ -668,7 +668,7 @@ class KeyHandler:
         # Build mask DataFrame with the appropriate column set
         cols = (
             MASK_COLUMNS_VEL
-            if self.meta.get("use_fixed_vel_mask")
+            if self.meta.get("use_fixed_window")
             else MASK_COLUMNS_FILE
         )
         if mask_rows:

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -20,7 +20,7 @@ For each cube, the pipeline:
      including the same ref_line combination logic, the strict spatial
      filter (here implemented as 2-D connected-component labelling per
      channel, the rectangular-grid equivalent of the hex-grid distance-based
-     filter), HFS mask extension, and the use_input_mask / use_fixed_vel_mask
+     filter), HFS mask extension, and the use_input_mask / use_fixed_window
      external-mask options. Before masking, two additional steps constrain
      the valid pixel area:
        a. Overlay footprint masking: pixels where the overlay cube has no
@@ -417,7 +417,7 @@ def build_hfs_mask_ppv(mask, line_name, hfs_data, delta_v_kms):
 def fixed_velocity_mask_ppv(shape, ov_hdr, mask_start, mask_end, mask_unit):
     """
     Build a binary PPV mask from a fixed velocity window, the array-native
-    equivalent of stage_regrid's use_fixed_vel_mask handling.
+    equivalent of stage_regrid's use_fixed_window handling.
 
     Parameters
     ----------
@@ -777,7 +777,7 @@ def run_moments_ppv(
     This function reproduces the mask-construction orchestration of
     stage_products.run_products (ref_line selection, ref_line combination
     modes, strict_mask, HFS extension, use_input_mask /
-    use_fixed_vel_mask) exactly, but operates on convolved PPV cubes
+    use_fixed_window) exactly, but operates on convolved PPV cubes
     (get_convolved_ppv_cube) and computes moments with get_mom_maps_ppv
     instead of working through the hex-grid .ecsv table.
 
@@ -804,7 +804,7 @@ def run_moments_ppv(
                    from channels outside the integration mask.
     """
     use_input_mask = meta.get("use_input_mask", False)
-    use_fixed_vel_mask = meta.get("use_fixed_vel_mask", False)
+    use_fixed_window = meta.get("use_fixed_window", False)
     if input_mask is None:
         input_mask = []
     use_hfs_lines = meta.get("use_hfs_lines", False)
@@ -983,15 +983,15 @@ def run_moments_ppv(
             mask = apply_strict_mask_ppv(mask.astype(int))
 
     # ------------------------------------------------------------------
-    # Apply combination tokens AND(input), OR(input), AND(fixed), OR(fixed).
+    # Apply combination tokens AND(input), OR(input), AND(window), OR(window).
     # ------------------------------------------------------------------
     def _get_ppv_ext(src):
-        """Load external mask for 'input' or 'fixed' source."""
+        """Load external mask for 'input' or 'window' source."""
         if len(input_mask) == 0:
             LOG.error(f"Combination token requires a mask but none is defined in config.")
             return None
-        if src == "fixed":
-            if not use_fixed_vel_mask:
+        if src == "window":
+            if not use_fixed_window:
                 return None
             mu   = input_mask["mask_unit"].iloc[0]
             mst  = float(input_mask["mask_start"].iloc[0]) * au.Unit(mu)
@@ -1016,8 +1016,8 @@ def run_moments_ppv(
         if src == "input" and not use_input_mask:
             LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
             continue
-        if src == "fixed" and not use_fixed_vel_mask:
-            LOG.warning(f"{op}(fixed) in ref_line but use_fixed_vel_mask = false — skipping.")
+        if src == "window" and not use_fixed_window:
+            LOG.warning(f"{op}(window) in ref_line but use_fixed_window = false — skipping.")
             continue
         ext_arr = _get_ppv_ext(src)
         if ext_arr is None:
@@ -1046,8 +1046,8 @@ def run_moments_ppv(
                 mask = mask & ext_arr
             LOG.info("Input mask AND-combined with PPV mask (legacy flag).")
 
-    if use_fixed_vel_mask and "fixed" not in handled_srcs:
-        ext_arr = _get_ppv_ext("fixed")
+    if use_fixed_window and "window" not in handled_srcs:
+        ext_arr = _get_ppv_ext("window")
         if ext_arr is not None:
             if mask_lines is None:
                 for ln in ppv_line_masks:
@@ -1241,7 +1241,7 @@ def run_fits(
     cubes      : pd.DataFrame — cube definitions from KeyHandler
     params     : dict         — target geometry from TargetHandler
     input_mask : pd.DataFrame, optional — mask definition from KeyHandler
-                (required if use_input_mask or use_fixed_vel_mask is set)
+                (required if use_input_mask or use_fixed_window is set)
     hfs_data   : pd.DataFrame or None, optional — hyperfine data from KeyHandler
                 (required if use_hfs_lines is set)
     """

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -77,7 +77,7 @@ from datetime import date
 
 from hexmaps.utils_fits import twod_head, conv_with_gauss, reproject_cube, resolve_meta_resolution
 from hexmaps.stage_regrid import _ensure_ms, _get_vaxis
-from hexmaps.utils_table import get_mom_maps, build_noise_mask, resolve_mask_lines
+from hexmaps.utils_table import get_mom_maps, build_noise_mask, resolve_mask_lines, parse_ref_line
 
 from hexmaps import __version__ as _HEXMAPS_VERSION
 from hexmaps.logger import get_logger
@@ -805,7 +805,6 @@ def run_moments_ppv(
     """
     use_input_mask = meta.get("use_input_mask", False)
     use_fixed_vel_mask = meta.get("use_fixed_vel_mask", False)
-    use_mask = use_input_mask or use_fixed_vel_mask
     if input_mask is None:
         input_mask = []
     use_hfs_lines = meta.get("use_hfs_lines", False)
@@ -941,87 +940,122 @@ def run_moments_ppv(
 
     # ------------------------------------------------------------------
     # Mask construction — mirrors stage_products.run_products exactly.
+    # parse_ref_line resolves mask_lines and combination tokens.
     # ------------------------------------------------------------------
-    if use_mask:
-        if len(input_mask) == 0:
-            LOG.error("use_mask is True but no mask defined in config.txt.")
-            raise ValueError("use_mask is True but no mask defined in config.txt.")
+    ppv_line_masks = {}
+    mask_lines, combinations = parse_ref_line(ref_line_method, line_names)
 
-        if use_fixed_vel_mask:
-            mask_unit = input_mask["mask_unit"].iloc[0]
-            mask_start = float(input_mask["mask_start"].iloc[0]) * au.Unit(mask_unit)
-            mask_end = float(input_mask["mask_end"].iloc[0]) * au.Unit(mask_unit)
-            mask = fixed_velocity_mask_ppv(
-                cube_data[ref_line].shape, ov_hdr, mask_start, mask_end, mask_unit
-            )
-            LOG.info(f"Fixed velocity mask applied ({mask_start} to {mask_end}).")
-        else:
-            mask_file = os.path.join(
+    if mask_lines is None:
+        # individual: one independent mask per line
+        LOG.info(f"Building individual PPV masks for {', '.join(line_names)}.")
+        for line in line_names:
+            if line not in cube_data:
+                continue
+            line_mask = construct_mask_ppv(cube_data[line].value, SN_processing)
+            if strict_mask:
+                line_mask = apply_strict_mask_ppv(line_mask.astype(int))
+            ppv_line_masks[line] = line_mask
+            LOG.info(f"Individual PPV mask built for {line}.")
+        # Union mask for edge-erosion and saved mask file
+        mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
+        for lm in ppv_line_masks.values():
+            mask = mask | np.asarray(lm).astype(int)
+
+    else:
+        # Build combined PPV mask by looping over resolved lines
+        LOG.info(f"Building PPV velocity mask from: {', '.join(mask_lines)}.")
+        mask = None
+        for line in mask_lines:
+            if line not in cube_data:
+                LOG.warning(f"Mask line {line} not in loaded cubes; skipping.")
+                continue
+            mask_line = construct_mask_ppv(cube_data[line].value, SN_processing)
+            mask = mask_line.astype(int) if mask is None else mask | mask_line.astype(int)
+            if mask is not mask_line.astype(int):
+                LOG.info(f"Combined PPV mask includes {line}.")
+
+        if mask is None:
+            LOG.error("No valid mask lines found; using empty mask.")
+            mask = np.zeros(next(iter(cube_data.values())).shape, dtype=int)
+
+        if strict_mask:
+            LOG.info("Applying strict spatial mask filter (connected-component, PPV grid).")
+            mask = apply_strict_mask_ppv(mask.astype(int))
+
+    # ------------------------------------------------------------------
+    # Apply combination tokens AND(input), OR(input), AND(fixed), OR(fixed).
+    # ------------------------------------------------------------------
+    def _get_ppv_ext(src):
+        """Load external mask for 'input' or 'fixed' source."""
+        if len(input_mask) == 0:
+            LOG.error(f"Combination token requires a mask but none is defined in config.")
+            return None
+        if src == "fixed":
+            if not use_fixed_vel_mask:
+                return None
+            mu   = input_mask["mask_unit"].iloc[0]
+            mst  = float(input_mask["mask_start"].iloc[0]) * au.Unit(mu)
+            mend = float(input_mask["mask_end"].iloc[0])   * au.Unit(mu)
+            return fixed_velocity_mask_ppv(
+                cube_data[ref_line].shape, ov_hdr, mst, mend, mu
+            ).astype(int)
+        else:  # input
+            if not use_input_mask:
+                return None
+            mfile = os.path.join(
                 str(input_mask["mask_dir"].iloc[0]),
                 target + str(input_mask["mask_ext"].iloc[0]),
             )
-            if not os.path.exists(mask_file):
-                LOG.error(f"Mask file not found: {mask_file}")
-                raise FileNotFoundError(f"Mask file not found: {mask_file}")
-            mask = external_mask_ppv(mask_file, ov_hdr, log=LOG)
-            LOG.info("External mask sampled onto PPV grid.")
-    else:
-        # ------------------------------------------------------------------
-        # Resolve which lines feed into the mask using the shared helper.
-        # Returns None for "individual" mode, or a list of line names to 
-        # OR-combine for all other modes.
-        # ------------------------------------------------------------------
-        ppv_line_masks = {}
-        mask_lines = resolve_mask_lines(ref_line_method, line_names)
+            if not os.path.exists(mfile):
+                LOG.error(f"Input mask file not found: {mfile}")
+                return None
+            return external_mask_ppv(mfile, ov_hdr, log=LOG).astype(int)
 
+    handled_srcs = set()
+    for op, src in combinations:
+        if src == "input" and not use_input_mask:
+            LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
+            continue
+        if src == "fixed" and not use_fixed_vel_mask:
+            LOG.warning(f"{op}(fixed) in ref_line but use_fixed_vel_mask = false — skipping.")
+            continue
+        ext_arr = _get_ppv_ext(src)
+        if ext_arr is None:
+            continue
+        handled_srcs.add(src)
+        LOG.info(f"Combining PPV mask {op} {src} mask.")
         if mask_lines is None:
-            # individual: one independent mask per line
-            LOG.info(
-                f"Building individual PPV masks for {', '.join(line_names)}."
-            )
-            for line in line_names:
-                if line not in cube_data:
-                    continue
-                line_mask = construct_mask_ppv(cube_data[line].value, SN_processing)
-                if strict_mask:
-                    line_mask = apply_strict_mask_ppv(line_mask.astype(int))
-                ppv_line_masks[line] = line_mask
-                LOG.info(f"Individual PPV mask built for {line}.")
-            # Combined union mask for edge-erosion and the saved mask file
-            mask = np.zeros_like(
-                next(iter(ppv_line_masks.values())), dtype=int
-            )
+            for ln in ppv_line_masks:
+                lm = np.asarray(ppv_line_masks[ln]).astype(int)
+                ppv_line_masks[ln] = (lm & ext_arr) if op == "AND" else (lm | ext_arr)
+            mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
             for lm in ppv_line_masks.values():
                 mask = mask | np.asarray(lm).astype(int)
-
         else:
-            # Build the combined mask by looping over the resolved lines
-            LOG.info(
-                f"Building PPV velocity mask from: {', '.join(mask_lines)}."
-            )
-            mask = None
-            for line in mask_lines:
-                if line not in cube_data:
-                    LOG.warning(f"Mask line {line} not in loaded cubes; skipping.")
-                    continue
-                mask_line = construct_mask_ppv(cube_data[line].value, SN_processing)
-                if mask is None:
-                    mask = mask_line.astype(int)
-                else:
-                    mask = mask | mask_line.astype(int)
-                    LOG.info(f"Combined PPV mask includes {line}.")
+            mask = (mask & ext_arr) if op == "AND" else (mask | ext_arr)
 
-            if mask is None:
-                LOG.error("No valid mask lines found; using empty mask.")
-                ref_shape = next(iter(cube_data.values())).shape
-                mask = np.zeros(ref_shape, dtype=int)
+    # Legacy flags
+    if use_input_mask and "input" not in handled_srcs:
+        ext_arr = _get_ppv_ext("input")
+        if ext_arr is not None:
+            if mask_lines is None:
+                for ln in ppv_line_masks:
+                    ppv_line_masks[ln] = np.asarray(ppv_line_masks[ln]).astype(int) & ext_arr
+                mask = mask & ext_arr
+            else:
+                mask = mask & ext_arr
+            LOG.info("Input mask AND-combined with PPV mask (legacy flag).")
 
-            if strict_mask:
-                LOG.info(
-                    "Applying strict spatial mask filter (connected-component, PPV grid)."
-                )
-                mask = apply_strict_mask_ppv(mask.astype(int))
-
+    if use_fixed_vel_mask and "fixed" not in handled_srcs:
+        ext_arr = _get_ppv_ext("fixed")
+        if ext_arr is not None:
+            if mask_lines is None:
+                for ln in ppv_line_masks:
+                    ppv_line_masks[ln] = np.asarray(ppv_line_masks[ln]).astype(int) & ext_arr
+                mask = mask & ext_arr
+            else:
+                mask = mask & ext_arr
+            LOG.info("Fixed velocity mask AND-combined with PPV mask (legacy flag).")
     # ------------------------------------------------------------------
     # Apply edge trimming: zero out the half-beam border of the footprint
     # across all channels. This removes convolution-edge artefacts from

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -343,7 +343,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     # Unpack settings from meta
     # ------------------------------------------------------------------
     use_input_mask = meta.get("use_input_mask", False)
-    use_fixed_vel_mask = meta.get("use_fixed_vel_mask", False)
+    use_fixed_window = meta.get("use_fixed_window", False)
     use_hfs_lines = meta.get("use_hfs_lines", False)
     strict_mask = meta.get("strict_mask", False)
     ref_line_method = meta.get("ref_line", "first")
@@ -376,7 +376,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     #   mask_lines   — which cube lines to OR-combine for the primary mask
     #                  (None signals individual mode)
     #   combinations — list of (op, src) pairs from combination tokens:
-    #                  AND(input), OR(input), AND(fixed), OR(fixed)
+    #                  AND(input), OR(input), AND(window), OR(window)
     # ------------------------------------------------------------------
     mask_lines, combinations = parse_ref_line(ref_line_method, line_names)
 
@@ -423,10 +423,10 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
         )
 
     # ------------------------------------------------------------------
-    # Apply combination tokens AND(input), OR(input), AND(fixed), OR(fixed).
+    # Apply combination tokens AND(input), OR(input), AND(window), OR(window).
     # ------------------------------------------------------------------
     def _get_ext_mask(src):
-        """Fetch the external mask array for 'input' or 'fixed' source."""
+        """Fetch the external mask array for 'input' or 'window' source."""
         if len(input_mask) == 0:
             LOG.error(f"Combination token requires a mask but none is defined in config.")
             return None
@@ -443,8 +443,8 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
         if src == "input" and not use_input_mask:
             LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
             continue
-        if src == "fixed" and not use_fixed_vel_mask:
-            LOG.warning(f"{op}(fixed) in ref_line but use_fixed_vel_mask = false — skipping.")
+        if src == "window" and not use_fixed_window:
+            LOG.warning(f"{op}(window) in ref_line but use_fixed_window = false — skipping.")
             continue
         ext_arr = _get_ext_mask(src)
         if ext_arr is None:
@@ -489,8 +489,8 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
                 )
             LOG.info("Input mask AND-combined (legacy use_input_mask flag).")
 
-    if use_fixed_vel_mask and "fixed" not in handled_srcs:
-        ext_arr = _get_ext_mask("fixed")
+    if use_fixed_window and "window" not in handled_srcs:
+        ext_arr = _get_ext_mask("window")
         if ext_arr is not None:
             if mask_lines is None:
                 for ln in line_masks:
@@ -503,9 +503,9 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
                 mask = (cur & ext_arr) * u.dimensionless_unscaled
                 this_data["SPEC_MASK"] = Column(
                     mask, unit=u.dimensionless_unscaled,
-                    description="Velocity-integration mask (AND fixed velocity mask)",
+                    description="Velocity-integration mask (AND window velocity mask)",
                 )
-            LOG.info("Fixed velocity mask AND-combined (legacy use_fixed_vel_mask flag).")
+            LOG.info("Fixed velocity mask AND-combined (legacy use_fixed_window flag).")
     # HFS mask extension
     lines_hfs = (
         list(set(hfs_data["hfs_name"]))

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -55,7 +55,7 @@ from astropy import units as u
 from astropy.stats import median_absolute_deviation
 from astropy.table import Table, Column
 
-from hexmaps.utils_table import shuffle, get_mom_maps, build_noise_mask, resolve_mask_lines
+from hexmaps.utils_table import shuffle, get_mom_maps, build_noise_mask, resolve_mask_lines, parse_ref_line
 
 from hexmaps.logger import get_logger
 
@@ -344,7 +344,6 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     # ------------------------------------------------------------------
     use_input_mask = meta.get("use_input_mask", False)
     use_fixed_vel_mask = meta.get("use_fixed_vel_mask", False)
-    use_mask = use_input_mask or use_fixed_vel_mask
     use_hfs_lines = meta.get("use_hfs_lines", False)
     strict_mask = meta.get("strict_mask", False)
     ref_line_method = meta.get("ref_line", "first")
@@ -373,70 +372,140 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     # ------------------------------------------------------------------
     # Mask construction
     # ------------------------------------------------------------------
-    if use_mask:
-        # Use an external mask that was sampled in stage_regrid
-        if len(input_mask) == 0:
-            LOG.error(f"use_mask is True but no mask defined in data_key.")
-        mask_tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
-        mask = this_data[mask_tag]
-        del this_data[
-            mask_tag
-        ]  # remove it from the table; will be re-added as SPEC_MASK
-        _, ref_line_vmean, _ = construct_mask(ref_line, this_data, SN_processing)
-        LOG.info(f"Using external mask: {mask_tag}.")
+    # parse_ref_line resolves:
+    #   mask_lines   — which cube lines to OR-combine for the primary mask
+    #                  (None signals individual mode)
+    #   combinations — list of (op, src) pairs from combination tokens:
+    #                  AND(input), OR(input), AND(fixed), OR(fixed)
+    # ------------------------------------------------------------------
+    mask_lines, combinations = parse_ref_line(ref_line_method, line_names)
+
+    if mask_lines is None:
+        # individual mode: build one mask per line
+        LOG.info(f"Building individual masks for {', '.join(line_names)}.")
+        line_masks, line_vmeans = construct_individual_mask(
+            line_names, this_data, SN_processing, use_hfs_lines, hfs_data, velocity_window
+        )
 
     else:
-        # ------------------------------------------------------------------
-        # Resolve which lines feed into the mask using the shared helper.
-        # resolve_mask_lines returns None for "individual" mode, or a list
-        # of uppercase line names to OR-combine for all other modes.
-        # ------------------------------------------------------------------
-        mask_lines = resolve_mask_lines(ref_line_method, line_names)
-
-        if mask_lines is None:
-            # individual: build one mask per line, used per-line below
-            LOG.info(f"Building individual masks for {', '.join(line_names)}.")
-            line_masks, line_vmeans = construct_individual_mask(
-                line_names, this_data, SN_processing, use_hfs_lines, hfs_data, velocity_window
-            )
-
-        else:
-            # Build the combined mask by looping over the resolved lines
-            LOG.info(
-                f"Building velocity mask from: {', '.join(mask_lines)}."
-            )
-            mask = None
-            ref_line_vmean = None
-            for line in mask_lines:
-                mask_line, vmean_line, _ = construct_mask(line, this_data, SN_processing)
-                this_data[f"SPEC_MASK_{line.upper()}"] = Column(
-                    mask_line,
-                    unit=u.dimensionless_unscaled,
-                    description=f"Velocity-integration mask for {line}",
-                )
-                if mask is None:
-                    mask = mask_line
-                    ref_line_vmean = vmean_line
-                    LOG.info(f"Building mask for line: {line}.")
-                else:
-                    mask = (
-                        mask.value.astype(int) | mask_line.value.astype(int)
-                    ) * u.dimensionless_unscaled
-                    LOG.info(f"Adding line to mask: {line}.")
-
-            # Optional strict spatial connectivity filter
-            if strict_mask:
-                LOG.info(f"Applying strict spatial mask filter.")
-                mask_arr = _apply_strict_mask(mask.value.astype(int), this_data)
-                mask = mask_arr * u.dimensionless_unscaled
-
-            # Store the combined mask used for integration
-            this_data["SPEC_MASK"] = Column(
-                mask,
+        # Build the combined S/N mask by looping over the resolved lines
+        LOG.info(f"Building velocity mask from: {', '.join(mask_lines)}.")
+        mask = None
+        ref_line_vmean = None
+        for line in mask_lines:
+            mask_line, vmean_line, _ = construct_mask(line, this_data, SN_processing)
+            this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                mask_line,
                 unit=u.dimensionless_unscaled,
-                description="Velocity-integration mask (used for all integrated products)",
+                description=f"Velocity-integration mask for {line}",
+            )
+            if mask is None:
+                mask = mask_line
+                ref_line_vmean = vmean_line
+                LOG.info(f"Building mask for line: {line}.")
+            else:
+                mask = (
+                    mask.value.astype(int) | mask_line.value.astype(int)
+                ) * u.dimensionless_unscaled
+                LOG.info(f"Adding line to mask: {line}.")
+
+        # Optional strict spatial connectivity filter
+        if strict_mask:
+            LOG.info(f"Applying strict spatial mask filter.")
+            mask_arr = _apply_strict_mask(mask.value.astype(int), this_data)
+            mask = mask_arr * u.dimensionless_unscaled
+
+        # Store the primary mask before any external combination
+        this_data["SPEC_MASK"] = Column(
+            mask,
+            unit=u.dimensionless_unscaled,
+            description="Velocity-integration mask (used for all integrated products)",
+        )
+
+    # ------------------------------------------------------------------
+    # Apply combination tokens AND(input), OR(input), AND(fixed), OR(fixed).
+    # ------------------------------------------------------------------
+    def _get_ext_mask(src):
+        """Fetch the external mask array for 'input' or 'fixed' source."""
+        if len(input_mask) == 0:
+            LOG.error(f"Combination token requires a mask but none is defined in config.")
+            return None
+        tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+        if tag not in this_data.colnames:
+            LOG.warning(f"External mask column {tag} not found in table; skipping.")
+            return None
+        ext = this_data[tag]
+        del this_data[tag]
+        return np.asarray(ext.value if hasattr(ext, "value") else ext).astype(int)
+
+    handled_srcs = set()
+    for op, src in combinations:
+        if src == "input" and not use_input_mask:
+            LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
+            continue
+        if src == "fixed" and not use_fixed_vel_mask:
+            LOG.warning(f"{op}(fixed) in ref_line but use_fixed_vel_mask = false — skipping.")
+            continue
+        ext_arr = _get_ext_mask(src)
+        if ext_arr is None:
+            continue
+        handled_srcs.add(src)
+        LOG.info(f"Combining primary mask {op} {src} mask.")
+        if mask_lines is None:
+            for ln in line_masks:
+                lm = np.asarray(
+                    line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
+                ).astype(int)
+                line_masks[ln] = (
+                    (lm & ext_arr) if op == "AND" else (lm | ext_arr)
+                ) * u.dimensionless_unscaled
+        else:
+            cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
+            mask = (
+                (cur & ext_arr) if op == "AND" else (cur | ext_arr)
+            ) * u.dimensionless_unscaled
+            this_data["SPEC_MASK"] = Column(
+                mask, unit=u.dimensionless_unscaled,
+                description=f"Velocity-integration mask ({op} {src} mask)",
             )
 
+    # Legacy flags: apply AND if the corresponding src was not already
+    # handled by an explicit combination token.
+    if use_input_mask and "input" not in handled_srcs:
+        ext_arr = _get_ext_mask("input")
+        if ext_arr is not None:
+            if mask_lines is None:
+                for ln in line_masks:
+                    lm = np.asarray(
+                        line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
+                    ).astype(int)
+                    line_masks[ln] = (lm & ext_arr) * u.dimensionless_unscaled
+            else:
+                cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
+                mask = (cur & ext_arr) * u.dimensionless_unscaled
+                this_data["SPEC_MASK"] = Column(
+                    mask, unit=u.dimensionless_unscaled,
+                    description="Velocity-integration mask (AND input mask)",
+                )
+            LOG.info("Input mask AND-combined (legacy use_input_mask flag).")
+
+    if use_fixed_vel_mask and "fixed" not in handled_srcs:
+        ext_arr = _get_ext_mask("fixed")
+        if ext_arr is not None:
+            if mask_lines is None:
+                for ln in line_masks:
+                    lm = np.asarray(
+                        line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
+                    ).astype(int)
+                    line_masks[ln] = (lm & ext_arr) * u.dimensionless_unscaled
+            else:
+                cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
+                mask = (cur & ext_arr) * u.dimensionless_unscaled
+                this_data["SPEC_MASK"] = Column(
+                    mask, unit=u.dimensionless_unscaled,
+                    description="Velocity-integration mask (AND fixed velocity mask)",
+                )
+            LOG.info("Fixed velocity mask AND-combined (legacy use_fixed_vel_mask flag).")
     # HFS mask extension
     lines_hfs = (
         list(set(hfs_data["hfs_name"]))

--- a/hexmaps/utils_table.py
+++ b/hexmaps/utils_table.py
@@ -519,10 +519,10 @@ def parse_ref_line(ref_line_method, line_names):
         (defined in the ``[mask]`` table with ``use_input_mask = true``).
     ``OR(input)``
         OR-combine the ref_line mask with the external input mask.
-    ``AND(fixed)``
+    ``AND(window)``
         AND-combine the ref_line mask with the fixed velocity-window mask
-        (defined in the ``[mask]`` table with ``use_fixed_vel_mask = true``).
-    ``OR(fixed)``
+        (defined in the ``[mask]`` table with ``use_fixed_window = true``).
+    ``OR(window)``
         OR-combine the ref_line mask with the fixed velocity-window mask.
 
     Combination tokens are stripped from the token list before line
@@ -532,10 +532,10 @@ def parse_ref_line(ref_line_method, line_names):
     --------
     ``ref_line = 12co21, AND(input)``
         Build the mask from 12co21, then AND with the input mask.
-    ``ref_line = first, OR(fixed)``
+    ``ref_line = first, OR(window)``
         Build the mask from the first line, then OR with the fixed window.
-    ``ref_line = all, AND(input), AND(fixed)``
-        Union of all line masks, ANDed with both the input and fixed masks.
+    ``ref_line = all, AND(input), AND(window)``
+        Union of all line masks, ANDed with both the input and window masks.
 
     Parameters
     ----------
@@ -553,7 +553,7 @@ def parse_ref_line(ref_line_method, line_names):
         Zero or more ``(operation, source)`` pairs describing how to
         combine the primary mask with external masks.
         *operation* is ``"AND"`` or ``"OR"``.
-        *source* is ``"input"`` or ``"fixed"``.
+        *source* is ``"input"`` or ``"window"``.
     """
     if not line_names:
         raise ValueError("parse_ref_line: line_names is empty.")
@@ -568,7 +568,7 @@ def parse_ref_line(ref_line_method, line_names):
     for tok in combo_tokens:
         tok_up = tok.upper()
         op     = tok_up.split("(")[0]          # "AND" or "OR"
-        src    = tok_up[len(op)+1:-1].lower()  # "input" or "fixed"
+        src    = tok_up[len(op)+1:-1].lower()  # "input" or "window"
         combinations.append((op, src))
 
     # Rejoin the non-combo tokens for the existing resolution logic

--- a/hexmaps/utils_table.py
+++ b/hexmaps/utils_table.py
@@ -504,72 +504,101 @@ def build_noise_mask(noise_mask_df, vaxis, shape):
         return np.broadcast_to(chan_mask[:, None, None], shape).copy()
 
 
-def resolve_mask_lines(ref_line_method, line_names):
+def parse_ref_line(ref_line_method, line_names):
     """
-    Resolve which lines to use for mask construction.
+    Parse the ``ref_line`` config value into masking lines and optional
+    combination directives.
 
-    Returns a list of uppercase line names that should be OR-combined to
-    produce the integration mask.  The caller loops over this list exactly
-    once: builds a mask per line, OR-combines them, and uses the result.
+    In addition to the existing line-selection keywords (``first``,
+    ``all``, ``n``, ``individual``, or named lines), the ``ref_line``
+    value may contain one or more **combination tokens** as
+    comma-separated extra items:
+
+    ``AND(input)``
+        AND-combine the ref_line mask with the external input mask
+        (defined in the ``[mask]`` table with ``use_input_mask = true``).
+    ``OR(input)``
+        OR-combine the ref_line mask with the external input mask.
+    ``AND(fixed)``
+        AND-combine the ref_line mask with the fixed velocity-window mask
+        (defined in the ``[mask]`` table with ``use_fixed_vel_mask = true``).
+    ``OR(fixed)``
+        OR-combine the ref_line mask with the fixed velocity-window mask.
+
+    Combination tokens are stripped from the token list before line
+    resolution so they do not interfere with line-name matching.
+
+    Examples
+    --------
+    ``ref_line = 12co21, AND(input)``
+        Build the mask from 12co21, then AND with the input mask.
+    ``ref_line = first, OR(fixed)``
+        Build the mask from the first line, then OR with the fixed window.
+    ``ref_line = all, AND(input), AND(fixed)``
+        Union of all line masks, ANDed with both the input and fixed masks.
 
     Parameters
     ----------
     ref_line_method : str or int
-        Value of config key ``ref_line``. One of:
-
-        ``"first"``
-            Only the first line in the cube list.
-        ``"<line_name>"`` or ``"<n1>, <n2>, ..."``
-            A single named line or a comma-separated list of line names.
-            Each name is matched case-insensitively against *line_names*.
-            Names not found in the list are warned and skipped.
-        ``"all"``
-            Every line in the cube list.
-        ``int`` or numeric string ``"n"``
-            First *n* lines (``n=1`` → first line only, same as ``"first"``).
-        ``"individual"``
-            Special mode: not handled here.  Returns ``None`` to signal
-            that the caller should build one mask per line independently.
-
+        Raw value of the ``ref_line`` config key.
     line_names : list of str
-        All cube line names in the order they appear in the config, as they
-        are stored in the database (typically lowercase, e.g. ``"12co21"``).
+        All cube line names (typically lowercase) from the config.
 
     Returns
     -------
-    list of str (uppercase) or None
-        Uppercase line names to use for masking, or ``None`` for
+    mask_lines : list of str (uppercase) or None
+        Lines to OR-combine for the primary mask, or ``None`` for
         ``individual`` mode.
-
-    Raises
-    ------
-    ValueError if no valid masking lines can be resolved.
+    combinations : list of (str, str)
+        Zero or more ``(operation, source)`` pairs describing how to
+        combine the primary mask with external masks.
+        *operation* is ``"AND"`` or ``"OR"``.
+        *source* is ``"input"`` or ``"fixed"``.
     """
     if not line_names:
-        raise ValueError("resolve_mask_lines: line_names is empty.")
+        raise ValueError("parse_ref_line: line_names is empty.")
 
-    # Individual mode — signal to caller
-    if str(ref_line_method).strip().lower() == "individual":
-        return None
+    # --------------- extract combination tokens first -------------------
+    _COMBO_TOKENS = {"AND(INPUT)", "OR(INPUT)", "AND(FIXED)", "OR(FIXED)"}
+    raw_tokens  = [t.strip() for t in str(ref_line_method).split(",")]
+    combo_tokens = [t for t in raw_tokens if t.upper() in _COMBO_TOKENS]
+    line_tokens  = [t for t in raw_tokens if t.upper() not in _COMBO_TOKENS]
+
+    combinations = []
+    for tok in combo_tokens:
+        tok_up = tok.upper()
+        op     = tok_up.split("(")[0]          # "AND" or "OR"
+        src    = tok_up[len(op)+1:-1].lower()  # "input" or "fixed"
+        combinations.append((op, src))
+
+    # Rejoin the non-combo tokens for the existing resolution logic
+    ref_core = ", ".join(line_tokens).strip().strip(",").strip()
+    if not ref_core:
+        ref_core = "first"
+
+    # --------------- resolve line tokens --------------------------------
+    # Individual mode
+    if ref_core.lower() == "individual":
+        return None, combinations
 
     # all
-    if str(ref_line_method).strip().lower() == "all":
-        return line_names
+    if ref_core.lower() == "all":
+        return line_names, combinations
 
-    # integer or numeric string → first n lines
+    # integer → first n lines
     try:
-        n = int(ref_line_method)
+        n = int(ref_core)
         n = max(1, min(n, len(line_names)))
-        return line_names[:n]
+        return line_names[:n], combinations
     except (ValueError, TypeError):
         pass
 
-    # "first" → first line only
-    if str(ref_line_method).strip().lower() == "first":
-        return [line_names[0]]
+    # "first"
+    if ref_core.lower() == "first":
+        return [line_names[0]], combinations
 
-    # Named line(s): comma-separated list or single name
-    candidates = [p.strip() for p in str(ref_line_method).split(",")]
+    # Named line(s)
+    candidates = [p.strip().upper() for p in ref_core.split(",")]
     resolved = []
     for c in candidates:
         if c in line_names:
@@ -577,15 +606,27 @@ def resolve_mask_lines(ref_line_method, line_names):
         else:
             import logging as _logging
             _logging.getLogger("hexmaps").warning(
-                f"resolve_mask_lines: '{c}' not found in cube list {line_names}; skipping."
+                f"parse_ref_line: '{c}' not found in cube list {line_names}; skipping."
             )
     if resolved:
-        return resolved
+        return resolved, combinations
 
-    # fallback — unrecognised value, use first line and warn
+    # Fallback
     import logging as _logging
     _logging.getLogger("hexmaps").warning(
-        f"resolve_mask_lines: unrecognised ref_line value '{ref_line_method}'; "
+        f"parse_ref_line: unrecognised ref_line value '{ref_line_method}'; "
         f"falling back to first line '{line_names[0]}'."
     )
-    return [line_names[0]]
+    return [line_names[0]], combinations
+
+
+def resolve_mask_lines(ref_line_method, line_names):
+    """
+    Backwards-compatible wrapper around :func:`parse_ref_line`.
+
+    Returns only the mask-line list (ignores combination tokens).
+    New code should call :func:`parse_ref_line` directly.
+    """
+    mask_lines, _ = parse_ref_line(ref_line_method, line_names)
+    return mask_lines
+


### PR DESCRIPTION
For instance, you can now combine a fixed velocity window with a signal-based mask, or compute line-individual masks within a fixed velocity window.

The new feature is triggered by additional keywords that are appended to the ref_line key in the config file.