### PR TITLE
Improved masking: combine masks + improved HFS logic

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -97,13 +97,13 @@ spire250,  SPIRE 250 um,      MJy/sr,  _spire250_gauss21.fits,  data/
 input_mask = co_mask, CO signal mask, _co_mask.fits, data/
 #
 # Example fixed-velocity mask (comment out if unused):
-window_mask = vel_mask, Fixed velocity window, -100, 100, km/s
+window_mask = window_mask, Fixed velocity window, 400, 600, km/s
 
 # Example noise velocity windows (comment out if unused):
 # Specify one or more line-free velocity ranges for noise (RMS) estimation.
 # Multiple windows are combined (OR) into a single noise channel mask.
-noise_mask = noise_mask, Noise window (blue), -200, -100, km/s
-noise_mask = noise_mask, Noise window (red),   100,  200, km/s
+noise_mask = noise_mask, Noise window (blue),   0,  400, km/s
+noise_mask = noise_mask, Noise window (red),  600,  800, km/s
 
 
 # -----------------------------------------------------------------------------

--- a/config.txt
+++ b/config.txt
@@ -72,7 +72,7 @@ folder_savefits = ./saved_fits_files/
 #
 # MASK TABLE (after "# ---- mask ----")
 #   For file mask  : name, description, file_extension, directory
-#   For window-vel  : name, description, start_vel, end_vel, unit
+#   For fixed-vel  : name, description, start_vel, end_vel, unit
 #   (leave section empty if no external mask is used)
 
 [targets]
@@ -96,7 +96,7 @@ spire250,  SPIRE 250 um,      MJy/sr,  _spire250_gauss21.fits,  data/
 # Example file mask (comment out if unused):
 # co_mask, CO signal mask, _co_mask.fits, data/
 #
-# Example fixed velocity window mask (comment out if unused):
+# Example fixed-velocity mask (comment out if unused):
 #vel_mask, Fixed velocity window, -100, 100, km/s
 
 # Example noise velocity windows (comment out if unused):
@@ -133,23 +133,33 @@ CDELT_SHUFF = 4000.0
 
 
 [masking]
-# Reference line for mask construction:
-#   first        - use the first line in the cube list above
-#   <LINE_NAME>  - use that specific line (case-insensitive)
-#   all          - use all lines
-#   n            - use first n lines
-#   individual   - compute one mask per line and apply individually
+# Reference line for mask construction.
+# A comma-separated list of tokens controls which masks are built and
+# how they are combined.
 #
-# Combination tokens (comma-separated, append to any keyword above):
-#   AND(input)   - AND-combine the ref_line mask with the input mask
-#   OR(input)    - OR-combine the ref_line mask with the input mask
-#   AND(window)  - AND-combine the ref_line mask with the fixed velocity window
-#   OR(window)   - OR-combine the ref_line mask with the fixed velocity window
+# Line-selection tokens (S/N mask from cube data):
+#   first        - first cube in the cube list (default)
+#   <LINE_NAME>  - a specific named line (case-insensitive)
+#   all          - all cubes
+#   n            - first n cubes
+#   individual   - one independent mask per cube, applied per-line
+#
+# External-mask tokens (additional masks to include):
+#   input        - external FITS mask (defined as a file row in [mask] table)
+#   window       - fixed velocity-window mask (vel_mask row in [mask] table)
+#
+# Combinator token (how all masks are combined; default: OR):
+#   OR           - include a sightline if it passes ANY mask (default)
+#   AND          - include a sightline only if it passes ALL masks
 #
 # Examples:
-#   ref_line = 12co21, AND(input)     -> 12co21 S/N mask AND input mask
-#   ref_line = first, OR(window)       -> first-line mask OR fixed window
-#   ref_line = all, AND(input)
+#   ref_line = first                  # S/N mask from first cube
+#   ref_line = 12co21                 # S/N mask from 12co21
+#   ref_line = first, input           # OR of first-cube mask and input mask
+#   ref_line = 12co21, input, AND     # 12co21 mask AND input mask
+#   ref_line = first, window, AND     # first-cube mask AND velocity window
+#   ref_line = all, input, window     # OR of all-cube + input + window masks
+#   ref_line = individual             # one mask per line
 ref_line = first
 
 # Signal-to-noise thresholds for the two-step mask: [low, high]
@@ -157,12 +167,6 @@ SN_processing = 2, 4
 
 # If true, apply a strict spatial consistency check on the mask
 strict_mask = false
-
-# Use an external mask FITS file defined in the [mask] table above.
-use_input_mask = false
-
-# Use a fixed velocity window defined in the [mask] table above
-use_fixed_window = false
 
 # Use explicit velocity windows (noise_mask rows in the [mask] table) for
 # noise (RMS) estimation instead of using channels outside the signal mask.

--- a/config.txt
+++ b/config.txt
@@ -94,16 +94,16 @@ spire250,  SPIRE 250 um,      MJy/sr,  _spire250_gauss21.fits,  data/
 
 # ---- mask ----
 # Example file mask (comment out if unused):
-# co_mask, CO signal mask, _co_mask.fits, data/
+input_mask = co_mask, CO signal mask, _co_mask.fits, data/
 #
 # Example fixed-velocity mask (comment out if unused):
-#vel_mask, Fixed velocity window, -100, 100, km/s
+window_mask = vel_mask, Fixed velocity window, -100, 100, km/s
 
 # Example noise velocity windows (comment out if unused):
 # Specify one or more line-free velocity ranges for noise (RMS) estimation.
 # Multiple windows are combined (OR) into a single noise channel mask.
-#noise_mask, Noise window (blue), -200, -100, km/s
-#noise_mask, Noise window (red),   100,  200, km/s
+noise_mask = noise_mask, Noise window (blue), -200, -100, km/s
+noise_mask = noise_mask, Noise window (red),   100,  200, km/s
 
 
 # -----------------------------------------------------------------------------

--- a/hexmaps/handler_keys.py
+++ b/hexmaps/handler_keys.py
@@ -131,6 +131,7 @@ class KeyHandler:
         self.maps = None
         self.cubes = None
         self.input_mask = None
+        self.window_mask = None
         self.noise_mask = None
         self.hfs_data = None
 
@@ -173,6 +174,9 @@ class KeyHandler:
     def get_input_mask(self) -> pd.DataFrame:
         """Return the DataFrame of mask definitions (may be empty)."""
         return self.input_mask
+
+    def get_window_mask(self) -> pd.DataFrame:
+        return self.window_mask
 
     def get_noise_mask(self) -> pd.DataFrame:
         """Return the DataFrame of noise velocity windows (may be empty)."""
@@ -592,7 +596,8 @@ class KeyHandler:
         # ------------------------------------------------------------------
         # Pass 2: parse the tabular sections line by line
         # ------------------------------------------------------------------
-        map_rows, cube_rows, mask_rows, noise_mask_rows = [], [], [], []
+        map_rows, cube_rows = [], []
+        input_mask_rows, window_mask_rows, noise_mask_rows = [], [], []
         section = None
 
         with open(self.conf_path, "r") as f:
@@ -613,9 +618,30 @@ class KeyHandler:
                     section = "mask"
                     continue
 
-                # Skip all other comments and ini-style [section]/key=value lines
+                # Skip all other comments and ini-style [section] headers
                 if line.startswith("#") or line.startswith("["):
                     continue
+
+                # ----------------------------------------------------------
+                # Mask section: lines have the form
+                #   input_mask  = name, desc, ext, dir
+                #   window_mask = name, desc, start, end, unit
+                #   noise_mask  = name, desc, start, end, unit
+                # Each key may appear multiple times (e.g. several noise rows).
+                # ----------------------------------------------------------
+                if section == "mask" and "=" in line:
+                    key, _, rest = line.partition("=")
+                    key  = key.strip().lower()
+                    parts = [p.strip() for p in rest.split(",")]
+                    if key == "input_mask" and len(parts) >= 4:
+                        input_mask_rows.append(parts)
+                    elif key == "window_mask" and len(parts) >= 5:
+                        window_mask_rows.append(parts)
+                    elif key == "noise_mask" and len(parts) >= 5:
+                        noise_mask_rows.append(parts)
+                    continue
+
+                # Plain comma-separated rows outside the mask section
                 if "=" in line and "," not in line:
                     continue
 
@@ -631,21 +657,12 @@ class KeyHandler:
                         parts.append("")
                     cube_rows.append(parts[: len(CUBE_COLUMNS)])
 
-                elif section == "mask" and len(parts) >= 3:
-                    # Route by first field: "noise_mask" rows go to noise_mask_rows
-                    if parts[0].lower() == "noise_mask":
-                        noise_mask_rows.append(parts)
-                    else:
-                        mask_rows.append(parts)
-
         # Build DataFrames
-        self.maps = pd.DataFrame(map_rows, columns=MAP_COLUMNS)
+        self.maps  = pd.DataFrame(map_rows,  columns=MAP_COLUMNS)
         self.cubes = pd.DataFrame(cube_rows, columns=CUBE_COLUMNS)
 
         # ------------------------------------------------------------------
         # Resolve relative map_dir / line_dir to absolute paths.
-        # This is essential so that stage_regrid can construct valid file
-        # paths regardless of where the user runs the pipeline from.
         # ------------------------------------------------------------------
         _base = Path(self.meta.get("_base", "."))
         if len(self.maps) > 0:
@@ -657,20 +674,46 @@ class KeyHandler:
                 lambda d: str((_base / d.strip()).resolve()) if d.strip() else d
             )
 
-        # Build mask DataFrame — detect column layout from the row content:
-        # velocity-window rows have 5 fields, file-mask rows have 4.
-        cols = MASK_COLUMNS_FILE  # default
-        if mask_rows:
-            n_fields = max(len(r) for r in mask_rows)
-            cols = MASK_COLUMNS_VEL if n_fields >= 5 else MASK_COLUMNS_FILE
-            padded = [r + [""] * max(0, len(cols) - len(r)) for r in mask_rows]
+        # ------------------------------------------------------------------
+        # input_mask: file-based external FITS mask
+        #   columns: mask_name, mask_desc, mask_ext, mask_dir
+        # ------------------------------------------------------------------
+        if input_mask_rows:
+            padded = [
+                r + [""] * max(0, len(MASK_COLUMNS_FILE) - len(r))
+                for r in input_mask_rows
+            ]
             self.input_mask = pd.DataFrame(
-                [r[: len(cols)] for r in padded], columns=cols
+                [r[: len(MASK_COLUMNS_FILE)] for r in padded],
+                columns=MASK_COLUMNS_FILE,
+            )
+            # Resolve mask_dir to absolute path
+            self.input_mask["mask_dir"] = self.input_mask["mask_dir"].apply(
+                lambda d: str((_base / d.strip()).resolve()) if d.strip() else d
             )
         else:
-            self.input_mask = pd.DataFrame(columns=cols)
+            self.input_mask = pd.DataFrame(columns=MASK_COLUMNS_FILE)
 
-        # Build noise_mask DataFrame (always velocity-window format)
+        # ------------------------------------------------------------------
+        # window_mask: fixed velocity-window mask
+        #   columns: mask_name, mask_desc, mask_start, mask_end, mask_unit
+        # ------------------------------------------------------------------
+        if window_mask_rows:
+            padded = [
+                r + [""] * max(0, len(MASK_COLUMNS_VEL) - len(r))
+                for r in window_mask_rows
+            ]
+            self.window_mask = pd.DataFrame(
+                [r[: len(MASK_COLUMNS_VEL)] for r in padded],
+                columns=MASK_COLUMNS_VEL,
+            )
+        else:
+            self.window_mask = pd.DataFrame(columns=MASK_COLUMNS_VEL)
+
+        # ------------------------------------------------------------------
+        # noise_mask: noise velocity windows for RMS estimation
+        #   columns: mask_name, mask_desc, mask_start, mask_end, mask_unit
+        # ------------------------------------------------------------------
         if noise_mask_rows:
             padded = [
                 r + [""] * max(0, len(NOISE_MASK_COLUMNS) - len(r))

--- a/hexmaps/handler_keys.py
+++ b/hexmaps/handler_keys.py
@@ -146,7 +146,7 @@ class KeyHandler:
 
         [resolution]/[masking]/[spectral]/[output]/[structure] are parsed
         before the [targets]/maps/cubes/mask tables so that masking flags
-        (use_fixed_window etc.) are available when parsing the mask table.
+        (use_fixed_vel_mask etc.) are available when parsing the mask table.
         _resolve_resolution runs last because it needs both overlay_file
         (set by _load_targets_and_tables) and target distances (set by
         _load_target_definitions).
@@ -353,8 +353,6 @@ class KeyHandler:
         ref_line          : str   — which line to use for mask construction. MANDATORY.
         SN_processing     : list  — [low_SN, high_SN] thresholds
         strict_mask       : bool  — apply spatial connectivity filter
-        use_input_mask    : bool  — use an external FITS mask from the [mask] table
-        use_fixed_window: bool  — use a fixed velocity-window mask
         use_fixed_noise_mask: bool — use explicit velocity windows for noise estimation
         use_hfs_lines     : bool  — apply HFS correction (requires hfs_file)
         fov_erosion_beams : float — FOV erosion in units of the beam FWHM (default 0.5);
@@ -425,12 +423,6 @@ class KeyHandler:
         ]
         self.meta["strict_mask"] = (
             _get("masking", "strict_mask", "false").lower() == "true"
-        )
-        self.meta["use_input_mask"] = (
-            _get("masking", "use_input_mask", "false").lower() == "true"
-        )
-        self.meta["use_fixed_window"] = (
-            _get("masking", "use_fixed_window", "false").lower() == "true"
         )
         self.meta["use_fixed_noise_mask"] = (
             _get("masking", "use_fixed_noise_mask", "false").lower() == "true"
@@ -665,13 +657,12 @@ class KeyHandler:
                 lambda d: str((_base / d.strip()).resolve()) if d.strip() else d
             )
 
-        # Build mask DataFrame with the appropriate column set
-        cols = (
-            MASK_COLUMNS_VEL
-            if self.meta.get("use_fixed_window")
-            else MASK_COLUMNS_FILE
-        )
+        # Build mask DataFrame — detect column layout from the row content:
+        # velocity-window rows have 5 fields, file-mask rows have 4.
+        cols = MASK_COLUMNS_FILE  # default
         if mask_rows:
+            n_fields = max(len(r) for r in mask_rows)
+            cols = MASK_COLUMNS_VEL if n_fields >= 5 else MASK_COLUMNS_FILE
             padded = [r + [""] * max(0, len(cols) - len(r)) for r in mask_rows]
             self.input_mask = pd.DataFrame(
                 [r[: len(cols)] for r in padded], columns=cols

--- a/hexmaps/handler_pipeline.py
+++ b/hexmaps/handler_pipeline.py
@@ -245,6 +245,7 @@ class PipelineHandler:
             maps=self.key_handler.get_maps(),
             cubes=self.key_handler.get_cubes(),
             input_mask=self.key_handler.get_input_mask(),
+            window_mask=self.key_handler.get_window_mask(),
         )
 
     def _run_products(self, target: str):
@@ -266,6 +267,7 @@ class PipelineHandler:
             meta=self.key_handler.meta,
             cubes=self.key_handler.get_cubes(),
             input_mask=self.key_handler.get_input_mask(),
+            window_mask=self.key_handler.get_window_mask(),
             hfs_data=self.key_handler.get_hfs_data(),
             noise_mask_df=self.key_handler.get_noise_mask(),
         )
@@ -292,6 +294,7 @@ class PipelineHandler:
             cubes=self.key_handler.get_cubes(),
             params=self.target_handler.get_target_params(target),
             input_mask=self.key_handler.get_input_mask(),
+            window_mask=self.key_handler.get_window_mask(),
             hfs_data=self.key_handler.get_hfs_data(),
             noise_mask_df=self.key_handler.get_noise_mask(),
         )

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -770,6 +770,7 @@ def run_moments_ppv(
     folder,
     save_mask=False,
     noise_mask_df=None,
+    window_mask=None,
 ):
     """
     Compute and write PPV-native moment maps for every cube of *target*.
@@ -849,23 +850,26 @@ def run_moments_ppv(
     #   use_window  — include the fixed velocity-window mask
     #   combinator  — "AND" or "OR" (default "OR")
     # ------------------------------------------------------------------
-    mask_lines, use_input, use_window, combinator = parse_ref_line(
+    mask_lines, use_individual, use_input, use_window, combinator = parse_ref_line(
         ref_line_method, line_names
     )
 
     # Helper: load an external PPV mask
     def _load_ppv_ext(kind):
-        if len(input_mask) == 0:
-            LOG.error(f"ref_line contains '{kind}' but no mask is defined in config.")
-            return None
         if kind == "window":
-            mu   = input_mask["mask_unit"].iloc[0]
-            mst  = float(input_mask["mask_start"].iloc[0]) * au.Unit(mu)
-            mend = float(input_mask["mask_end"].iloc[0])   * au.Unit(mu)
+            if window_mask is None or len(window_mask) == 0:
+                LOG.error("ref_line contains 'window' but no window_mask is defined.")
+                return None
+            mu   = window_mask["mask_unit"].iloc[0]
+            mst  = float(window_mask["mask_start"].iloc[0]) * au.Unit(mu)
+            mend = float(window_mask["mask_end"].iloc[0])   * au.Unit(mu)
             return fixed_velocity_mask_ppv(
                 cube_data[ref_line].shape, ov_hdr, mst, mend, mu
             ).astype(int)
-        else:  # input
+        else:  # "input"
+            if input_mask is None or len(input_mask) == 0:
+                LOG.error("ref_line contains 'input' but no input_mask is defined.")
+                return None
             mfile = os.path.join(
                 str(input_mask["mask_dir"].iloc[0]),
                 target + str(input_mask["mask_ext"].iloc[0]),
@@ -878,7 +882,7 @@ def run_moments_ppv(
     ppv_line_masks = {}
 
     # ---- individual mode ------------------------------------------------
-    if mask_lines is None:
+    if use_individual:
         LOG.info(f"Building individual PPV masks for {', '.join(line_names)}.")
         for line in line_names:
             if line not in cube_data:
@@ -975,7 +979,7 @@ def run_moments_ppv(
         LOG.info(
             f"PPV mask cube written to: {os.path.join(folder, f'{target}_mask.fits')}"
         )
-        if ref_line_method == "individual":
+        if use_individual:
             for line, lm in ppv_line_masks.items():
                 lm_edge = (np.asarray(lm) * edge_mask[None, :, :]).astype(int)
                 save_ppv_mask_to_fits(
@@ -996,7 +1000,7 @@ def run_moments_ppv(
             continue
 
         active_mask = mask
-        if ref_line_method == "individual":
+        if use_individual:
             # Use this line's own mask, falling back to the union mask if absent.
             active_mask = ppv_line_masks.get(line_name, mask)
         elif use_hfs_lines and hfs_data is not None:
@@ -1095,6 +1099,7 @@ def run_fits(
     cubes,
     params,
     input_mask=None,
+    window_mask=None,
     hfs_data=None,
     noise_mask_df=None,
 ):
@@ -1188,6 +1193,7 @@ def run_fits(
             folder,
             save_mask=save_mask,
             noise_mask_df=noise_mask_df,
+            window_mask=window_mask,
         )
         LOG.info(f"Moment map FITS files written to: {folder}")
     elif save_mask:

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -909,16 +909,32 @@ def run_moments_ppv(
             if strict_mask:
                 lm = apply_strict_mask_ppv(lm)
 
-            # Combine with external masks per-line
+            # Combine with external masks per-line.
+            # When use_hfs_lines is True and the line has HFS satellite entries,
+            # the external mask is first duplicated and shifted to each satellite
+            # frequency before combining, so it covers the same spectral extent
+            # as the per-line S/N mask.
             if use_input:
                 ext = _load_ppv_ext("input")
                 if ext is not None:
-                    lm = (lm & ext) if combinator == "AND" else (lm | ext)
+                    ext_line = ext
+                    if use_hfs_lines and hfs_data is not None:
+                        ext_hfs = build_hfs_mask_ppv(ext.astype(float), line, hfs_data, delta_v_kms)
+                        if ext_hfs is not None:
+                            ext_line = ext_hfs.astype(int)
+                            LOG.info(f"External input mask shifted to HFS frequencies for {line}.")
+                    lm = (lm & ext_line) if combinator == "AND" else (lm | ext_line)
                     LOG.info(f"PPV mask for {line} {combinator} input mask.")
             if use_window:
                 ext = _load_ppv_ext("window")
                 if ext is not None:
-                    lm = (lm & ext) if combinator == "AND" else (lm | ext)
+                    ext_line = ext
+                    if use_hfs_lines and hfs_data is not None:
+                        ext_hfs = build_hfs_mask_ppv(ext.astype(float), line, hfs_data, delta_v_kms)
+                        if ext_hfs is not None:
+                            ext_line = ext_hfs.astype(int)
+                            LOG.info(f"External window mask shifted to HFS frequencies for {line}.")
+                    lm = (lm & ext_line) if combinator == "AND" else (lm | ext_line)
                     LOG.info(f"PPV mask for {line} {combinator} window mask.")
 
             ppv_line_masks[ln_upper] = lm

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -965,39 +965,13 @@ def run_moments_ppv(
         if use_input:
             ext = _load_ppv_ext("input")
             if ext is not None:
-                if use_hfs_lines and hfs_data is not None:
-                    lines_hfs_names = list(set(hfs_data["hfs_name"]))
-                    ext_extended = ext.astype(int).copy()
-                    for line in line_names:
-                        if line in lines_hfs_names:
-                            ext_hfs = build_hfs_mask_ppv(
-                                ext.astype(float), line, hfs_data, delta_v_kms
-                            )
-                            if ext_hfs is not None:
-                                ext_extended = ext_extended | ext_hfs.astype(int)
-                                LOG.info(f"External input mask extended to HFS frequencies for {line}.")
-                    mask_parts.append(ext_extended)
-                else:
-                    mask_parts.append(ext)
+                mask_parts.append(ext)
                 LOG.info("Input mask included in PPV mask.")
 
         if use_window:
             ext = _load_ppv_ext("window")
             if ext is not None:
-                if use_hfs_lines and hfs_data is not None:
-                    lines_hfs_names = list(set(hfs_data["hfs_name"]))
-                    ext_extended = ext.astype(int).copy()
-                    for line in line_names:
-                        if line in lines_hfs_names:
-                            ext_hfs = build_hfs_mask_ppv(
-                                ext.astype(float), line, hfs_data, delta_v_kms
-                            )
-                            if ext_hfs is not None:
-                                ext_extended = ext_extended | ext_hfs.astype(int)
-                                LOG.info(f"External window mask extended to HFS frequencies for {line}.")
-                    mask_parts.append(ext_extended)
-                else:
-                    mask_parts.append(ext)
+                mask_parts.append(ext)
                 LOG.info("Velocity-window mask included in PPV mask.")
 
         if not mask_parts:
@@ -1013,6 +987,24 @@ def run_moments_ppv(
         if strict_mask:
             LOG.info("Applying strict spatial mask filter (PPV).")
             mask = apply_strict_mask_ppv(mask.astype(int))
+
+        # HFS mask extension — mirrors stage_products combined mode.
+        # For each HFS-capable line, extend the master mask to its satellite
+        # frequencies and store the result in ppv_line_masks so the moment
+        # loop picks it up via active_mask.  Each line keeps its own
+        # independent integration window; no line is contaminated by the
+        # satellite channels of any other line.
+        if use_hfs_lines and hfs_data is not None:
+            lines_hfs = list(set(hfs_data["hfs_name"]))
+            for line in line_names:
+                if line not in lines_hfs:
+                    continue
+                LOG.info(f"Building HFS PPV mask for {line}.")
+                mask_hfs = build_hfs_mask_ppv(
+                    mask.astype(float), line, hfs_data, delta_v_kms
+                )
+                if mask_hfs is not None:
+                    ppv_line_masks[line.upper()] = mask_hfs.astype(int)
 
     # ------------------------------------------------------------------
     # Edge trimming + NaN masking
@@ -1056,26 +1048,25 @@ def run_moments_ppv(
         if ln_upper not in cube_data:
             continue
 
-        # Select the mask for this line
+        # Select the mask for this line.
+        # use_individual              → per-line S/N mask from ppv_line_masks
+        # use_hfs_lines + HFS entry  → HFS-extended master mask from ppv_line_masks
+        # otherwise                  → master mask for all lines
         if use_individual:
             active_mask = ppv_line_masks.get(ln_upper, mask)
-        elif use_hfs_lines and hfs_data is not None:
-            mask_hfs = build_hfs_mask_ppv(mask, line_name, hfs_data, delta_v_kms)
-            if mask_hfs is not None:
-                active_mask = mask_hfs
-                LOG.info(f"Using HFS-extended PPV mask for {line_name}.")
-                if save_mask and not np.array_equal(mask_hfs, mask):
-                    hfs_mask_name = f"mask_{line_name.lower()}"
-                    save_ppv_mask_to_fits(
-                        mask_hfs, ov_hdr, target, hfs_mask_name,
-                        folder, out_nan_mask=out_nan_mask,
-                    )
-                    LOG.info(
-                        f"PPV mask cube for {line_name} written to: "
-                        f"{os.path.join(folder, f'{target}_{hfs_mask_name}.fits')}"
-                    )
-            else:
-                active_mask = mask
+        elif use_hfs_lines and hfs_data is not None and ln_upper in ppv_line_masks:
+            active_mask = ppv_line_masks[ln_upper]
+            LOG.info(f"Using HFS-extended PPV mask for {line_name}.")
+            if save_mask and not np.array_equal(active_mask, mask):
+                hfs_mask_name = f"mask_{line_name.lower()}"
+                save_ppv_mask_to_fits(
+                    active_mask, ov_hdr, target, hfs_mask_name,
+                    folder, out_nan_mask=out_nan_mask,
+                )
+                LOG.info(
+                    f"PPV mask cube for {line_name} written to: "
+                    f"{os.path.join(folder, f'{target}_{hfs_mask_name}.fits')}"
+                )
         else:
             active_mask = mask
 

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -20,7 +20,7 @@ For each cube, the pipeline:
      including the same ref_line combination logic, the strict spatial
      filter (here implemented as 2-D connected-component labelling per
      channel, the rectangular-grid equivalent of the hex-grid distance-based
-     filter), HFS mask extension, and the use_input_mask / use_fixed_window
+     filter), HFS mask extension, and the use_input_mask / use_fixed_vel_mask
      external-mask options. Before masking, two additional steps constrain
      the valid pixel area:
        a. Overlay footprint masking: pixels where the overlay cube has no
@@ -77,7 +77,7 @@ from datetime import date
 
 from hexmaps.utils_fits import twod_head, conv_with_gauss, reproject_cube, resolve_meta_resolution
 from hexmaps.stage_regrid import _ensure_ms, _get_vaxis
-from hexmaps.utils_table import get_mom_maps, build_noise_mask, resolve_mask_lines, parse_ref_line
+from hexmaps.utils_table import get_mom_maps, build_noise_mask, parse_ref_line
 
 from hexmaps import __version__ as _HEXMAPS_VERSION
 from hexmaps.logger import get_logger
@@ -417,7 +417,7 @@ def build_hfs_mask_ppv(mask, line_name, hfs_data, delta_v_kms):
 def fixed_velocity_mask_ppv(shape, ov_hdr, mask_start, mask_end, mask_unit):
     """
     Build a binary PPV mask from a fixed velocity window, the array-native
-    equivalent of stage_regrid's use_fixed_window handling.
+    equivalent of stage_regrid's use_fixed_vel_mask handling.
 
     Parameters
     ----------
@@ -777,7 +777,7 @@ def run_moments_ppv(
     This function reproduces the mask-construction orchestration of
     stage_products.run_products (ref_line selection, ref_line combination
     modes, strict_mask, HFS extension, use_input_mask /
-    use_fixed_window) exactly, but operates on convolved PPV cubes
+    use_fixed_vel_mask) exactly, but operates on convolved PPV cubes
     (get_convolved_ppv_cube) and computes moments with get_mom_maps_ppv
     instead of working through the hex-grid .ecsv table.
 
@@ -803,196 +803,62 @@ def run_moments_ppv(
                    estimated from channels within these windows rather than
                    from channels outside the integration mask.
     """
-    use_input_mask = meta.get("use_input_mask", False)
-    use_fixed_window = meta.get("use_fixed_window", False)
-    if input_mask is None:
-        input_mask = []
-    use_hfs_lines = meta.get("use_hfs_lines", False)
-    strict_mask = meta.get("strict_mask", False)
-    ref_line_method = meta.get("ref_line", "first")
-    SN_processing = meta.get("SN_processing", [2, 4])
-    mom_calc = [
-        meta.get("mom_thresh", 5),
-        meta.get("conseq_channels", 3),
-        meta.get("mom2_method", "fwhm"),
-    ]
-    data_dir = meta.get("data_dir", "data/")
-
-    line_names = [str(l) for l in cubes["line_name"]]
-    n_lines = len(line_names)
-
-    ref_line = (
-        ref_line_method
-        if ref_line_method in line_names
-        else line_names[0]
-    )
-
     # ------------------------------------------------------------------
-    # Load the overlay cube to get the reference WCS/spectral axis.
+    # Unpack settings from meta
     # ------------------------------------------------------------------
-    overlay_file = meta.get("overlay_file", "")
-    overlay_fname = (
-        os.path.join(data_dir, overlay_file)
-        if target in overlay_file
-        else os.path.join(data_dir, target + overlay_file)
-    )
-    if not os.path.exists(overlay_fname):
-        LOG.error(f"Overlay file not found: {overlay_fname}")
-        raise FileNotFoundError(f"Overlay file not found: {overlay_fname}")
-    #LOG.info(f"Overlay file: {overlay_fname}")
-    ov_data, ov_hdr = fits.getdata(overlay_fname, header=True)
-    ov_hdr, _ = _ensure_ms(copy.copy(ov_hdr))
+    ref_line_method  = meta.get("ref_line", "first")
+    SN_processing    = meta.get("SN_processing", [2, 4])
+    strict_mask      = meta.get("strict_mask", False)
+    use_hfs_lines    = meta.get("use_hfs_lines", False)
 
-    target_res_as = meta["target_res"]
+    line_names = [str(ln) for ln in cubes["line_name"]]
+    n_lines    = len(line_names)
 
-    delta_v_kms = (
-        (ov_hdr["CDELT3"] * au.Unit(ov_hdr.get("CUNIT3", "m/s"))).to(au.km / au.s).value
-    )
-    vaxis = (_get_vaxis(ov_hdr) * au.Unit(ov_hdr.get("CUNIT3", "m/s"))).to(au.km / au.s)
-
-    # ------------------------------------------------------------------
-    # Build the noise channel mask (PPV path).
-    # If use_fixed_noise_mask is True and noise_mask_df is non-empty,
-    # build a (n_chan, ny, nx) boolean mask selecting the noise channels.
-    # This is passed to get_mom_maps_ppv so RMS is estimated from those
-    # channels rather than from the inverse of the integration mask.
-    # ------------------------------------------------------------------
-    use_fixed_noise_mask = meta.get("use_fixed_noise_mask", False)
-    ppv_noise_mask = None
-    if use_fixed_noise_mask:
-        if noise_mask_df is not None and len(noise_mask_df) > 0:
-            # Shape determined after cubes are loaded; use a placeholder for
-            # now and rebuild with the correct shape inside the per-line loop.
-            _noise_mask_df = noise_mask_df
-            LOG.info(
-                f"Noise RMS will be estimated from {len(noise_mask_df)} "
-                "fixed velocity window(s)."
-            )
-        else:
-            LOG.warning(
-                "use_fixed_noise_mask is True but no noise_mask rows found "
-                "in the [mask] table. Falling back to mask-inverted noise."
-            )
-            _noise_mask_df = None
-    else:
-        _noise_mask_df = None
-
-    # ------------------------------------------------------------------
-    # Load every cube's convolved PPV data up front (needed both for mask
-    # construction and the per-line moment computation below).
-    # Also read the raw input headers before convolution so we can copy the
-    # correct per-line RESTFRQ into output FITS headers (reprojection
-    # overwrites the cube header with the overlay header, losing RESTFRQ).
-    # ------------------------------------------------------------------
+    # Load and convolve all cubes up front (NaN masking applied per-cube later)
     cube_data = {}
     cube_hdrs = {}
     for _, row in cubes.iterrows():
-        name = str(row["line_name"])
+        name = str(row["line_name"]).upper()
         raw_path = os.path.join(str(row["line_dir"]), target + str(row["line_ext"]))
-        cube_hdrs[name] = (
-            fits.getheader(raw_path) if os.path.exists(raw_path) else {}
-        )
+        cube_hdrs[name] = fits.getheader(raw_path) if os.path.exists(raw_path) else {}
         data, _ = get_convolved_ppv_cube(
-            target,
-            name,
-            str(row["line_dir"]),
-            str(row["line_ext"]),
-            meta,
-            ov_hdr,
-            log=LOG,
+            target, str(row["line_name"]), str(row["line_dir"]),
+            str(row["line_ext"]), meta, ov_hdr, log=LOG,
         )
         cube_data[name] = data * au.Unit(str(row["line_unit"]))
 
+    # ref_line: the primary single line name used for vmean / shape fallback
+    line_names_upper = [ln.upper() for ln in line_names]
+    ref_line_str = str(ref_line_method).split(",")[0].strip().upper()
+    ref_line = (
+        ref_line_str
+        if ref_line_str in line_names_upper
+        else line_names_upper[0]
+    )
     if ref_line not in cube_data:
         LOG.warning(
             f"Nominal reference line {ref_line} not found; "
-            f"mask construction will use available cubes via resolve_mask_lines."
+            f"mask construction will use available cubes via parse_ref_line."
         )
 
     # ------------------------------------------------------------------
-    # Step 1: constrain every convolved cube to the overlay's valid-pixel
-    # footprint. Pixels where the overlay has no finite values along the
-    # entire velocity axis (i.e. outside the observed area) are set to NaN
-    # in all convolved cubes. This ensures the footprint used for edge
-    # erosion reflects the actual data coverage, not just the reprojected
-    # grid extent, and propagates NaN correctly through to the moments.
+    # Mask construction — PPV-native equivalent of stage_products.
+    # parse_ref_line decodes ref_line into:
+    #   mask_lines  — cube lines for S/N masking (None=individual, []=none)
+    #   use_input   — include the external FITS input mask
+    #   use_window  — include the fixed velocity-window mask
+    #   combinator  — "AND" or "OR" (default "OR")
     # ------------------------------------------------------------------
-    ov_footprint = np.any(np.isfinite(ov_data), axis=0)  # (ny, nx) bool
-    for name in cube_data:
-        cube_val = cube_data[name].value.copy()
-        cube_val[:, ~ov_footprint] = np.nan
-        cube_data[name] = cube_val * cube_data[name].unit
-
-    # ------------------------------------------------------------------
-    # Step 2: build a 2-D edge mask by eroding the *overlay's* non-NaN
-    # blob (ov_footprint) by half a beam width. Using the overlay footprint
-    # directly — rather than deriving a footprint from the convolved cube —
-    # ensures the erosion follows the true irregular observed boundary,
-    # including any concavities, rather than the rectangular reprojected
-    # grid extent.
-    # ------------------------------------------------------------------
-    edge_mask = build_edge_mask(
-        ov_footprint,
-        ov_hdr,
-        target_res_as,
-        fov_erosion_beams=meta.get("fov_erosion_beams", 0.5),
+    mask_lines, use_input, use_window, combinator = parse_ref_line(
+        ref_line_method, line_names
     )
 
-    # ------------------------------------------------------------------
-    # Mask construction — mirrors stage_products.run_products exactly.
-    # parse_ref_line resolves mask_lines and combination tokens.
-    # ------------------------------------------------------------------
-    ppv_line_masks = {}
-    mask_lines, combinations = parse_ref_line(ref_line_method, line_names)
-
-    if mask_lines is None:
-        # individual: one independent mask per line
-        LOG.info(f"Building individual PPV masks for {', '.join(line_names)}.")
-        for line in line_names:
-            if line not in cube_data:
-                continue
-            line_mask = construct_mask_ppv(cube_data[line].value, SN_processing)
-            if strict_mask:
-                line_mask = apply_strict_mask_ppv(line_mask.astype(int))
-            ppv_line_masks[line] = line_mask
-            LOG.info(f"Individual PPV mask built for {line}.")
-        # Union mask for edge-erosion and saved mask file
-        mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
-        for lm in ppv_line_masks.values():
-            mask = mask | np.asarray(lm).astype(int)
-
-    else:
-        # Build combined PPV mask by looping over resolved lines
-        LOG.info(f"Building PPV velocity mask from: {', '.join(mask_lines)}.")
-        mask = None
-        for line in mask_lines:
-            if line not in cube_data:
-                LOG.warning(f"Mask line {line} not in loaded cubes; skipping.")
-                continue
-            mask_line = construct_mask_ppv(cube_data[line].value, SN_processing)
-            mask = mask_line.astype(int) if mask is None else mask | mask_line.astype(int)
-            if mask is not mask_line.astype(int):
-                LOG.info(f"Combined PPV mask includes {line}.")
-
-        if mask is None:
-            LOG.error("No valid mask lines found; using empty mask.")
-            mask = np.zeros(next(iter(cube_data.values())).shape, dtype=int)
-
-        if strict_mask:
-            LOG.info("Applying strict spatial mask filter (connected-component, PPV grid).")
-            mask = apply_strict_mask_ppv(mask.astype(int))
-
-    # ------------------------------------------------------------------
-    # Apply combination tokens AND(input), OR(input), AND(window), OR(window).
-    # ------------------------------------------------------------------
-    def _get_ppv_ext(src):
-        """Load external mask for 'input' or 'window' source."""
+    # Helper: load an external PPV mask
+    def _load_ppv_ext(kind):
         if len(input_mask) == 0:
-            LOG.error(f"Combination token requires a mask but none is defined in config.")
+            LOG.error(f"ref_line contains '{kind}' but no mask is defined in config.")
             return None
-        if src == "window":
-            if not use_fixed_window:
-                return None
+        if kind == "window":
             mu   = input_mask["mask_unit"].iloc[0]
             mst  = float(input_mask["mask_start"].iloc[0]) * au.Unit(mu)
             mend = float(input_mask["mask_end"].iloc[0])   * au.Unit(mu)
@@ -1000,8 +866,6 @@ def run_moments_ppv(
                 cube_data[ref_line].shape, ov_hdr, mst, mend, mu
             ).astype(int)
         else:  # input
-            if not use_input_mask:
-                return None
             mfile = os.path.join(
                 str(input_mask["mask_dir"].iloc[0]),
                 target + str(input_mask["mask_ext"].iloc[0]),
@@ -1011,51 +875,74 @@ def run_moments_ppv(
                 return None
             return external_mask_ppv(mfile, ov_hdr, log=LOG).astype(int)
 
-    handled_srcs = set()
-    for op, src in combinations:
-        if src == "input" and not use_input_mask:
-            LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
-            continue
-        if src == "window" and not use_fixed_window:
-            LOG.warning(f"{op}(window) in ref_line but use_fixed_window = false — skipping.")
-            continue
-        ext_arr = _get_ppv_ext(src)
-        if ext_arr is None:
-            continue
-        handled_srcs.add(src)
-        LOG.info(f"Combining PPV mask {op} {src} mask.")
-        if mask_lines is None:
-            for ln in ppv_line_masks:
-                lm = np.asarray(ppv_line_masks[ln]).astype(int)
-                ppv_line_masks[ln] = (lm & ext_arr) if op == "AND" else (lm | ext_arr)
-            mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
-            for lm in ppv_line_masks.values():
-                mask = mask | np.asarray(lm).astype(int)
+    ppv_line_masks = {}
+
+    # ---- individual mode ------------------------------------------------
+    if mask_lines is None:
+        LOG.info(f"Building individual PPV masks for {', '.join(line_names)}.")
+        for line in line_names:
+            if line not in cube_data:
+                continue
+            lm = construct_mask_ppv(cube_data[line].value, SN_processing).astype(int)
+            if strict_mask:
+                lm = apply_strict_mask_ppv(lm)
+            # Apply external masks per-line if requested
+            for kind in ([("input")] if use_input else []) + ([("window")] if use_window else []):
+                ext = _load_ppv_ext(kind)
+                if ext is not None:
+                    lm = (lm & ext) if combinator == "AND" else (lm | ext)
+                    LOG.info(f"Individual PPV mask for {line} {combinator} {kind} mask.")
+            ppv_line_masks[line] = lm
+            LOG.info(f"Individual PPV mask built for {line}.")
+        # Union for edge-erosion and saved combined mask
+        mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
+        for lm in ppv_line_masks.values():
+            mask = mask | np.asarray(lm).astype(int)
+
+    # ---- combined mask mode ---------------------------------------------
+    else:
+        mask_parts = []
+
+        # S/N masks from cube lines
+        if mask_lines:
+            LOG.info(f"Building PPV velocity mask from: {', '.join(mask_lines)}.")
+            for line in mask_lines:
+                if line not in cube_data:
+                    LOG.warning(f"Mask line {line} not in loaded cubes; skipping.")
+                    continue
+                mask_parts.append(
+                    construct_mask_ppv(cube_data[line].value, SN_processing).astype(int)
+                )
+                LOG.info(f"PPV mask includes {line}.")
+
+        # External input mask
+        if use_input:
+            ext = _load_ppv_ext("input")
+            if ext is not None:
+                mask_parts.append(ext)
+                LOG.info("Input mask included in PPV mask.")
+
+        # Fixed velocity-window mask
+        if use_window:
+            ext = _load_ppv_ext("window")
+            if ext is not None:
+                mask_parts.append(ext)
+                LOG.info("Velocity-window mask included in PPV mask.")
+
+        # Combine all parts
+        if not mask_parts:
+            LOG.warning("No PPV mask parts resolved; using empty mask.")
+            mask = np.zeros(next(iter(cube_data.values())).shape, dtype=int)
         else:
-            mask = (mask & ext_arr) if op == "AND" else (mask | ext_arr)
+            mask = mask_parts[0].copy()
+            for part in mask_parts[1:]:
+                mask = (mask & part) if combinator == "AND" else (mask | part)
+            if len(mask_parts) > 1:
+                LOG.info(f"Combined {len(mask_parts)} PPV mask(s) with {combinator}.")
 
-    # Legacy flags
-    if use_input_mask and "input" not in handled_srcs:
-        ext_arr = _get_ppv_ext("input")
-        if ext_arr is not None:
-            if mask_lines is None:
-                for ln in ppv_line_masks:
-                    ppv_line_masks[ln] = np.asarray(ppv_line_masks[ln]).astype(int) & ext_arr
-                mask = mask & ext_arr
-            else:
-                mask = mask & ext_arr
-            LOG.info("Input mask AND-combined with PPV mask (legacy flag).")
-
-    if use_fixed_window and "window" not in handled_srcs:
-        ext_arr = _get_ppv_ext("window")
-        if ext_arr is not None:
-            if mask_lines is None:
-                for ln in ppv_line_masks:
-                    ppv_line_masks[ln] = np.asarray(ppv_line_masks[ln]).astype(int) & ext_arr
-                mask = mask & ext_arr
-            else:
-                mask = mask & ext_arr
-            LOG.info("Fixed velocity mask AND-combined with PPV mask (legacy flag).")
+        if strict_mask:
+            LOG.info("Applying strict spatial mask filter (PPV).")
+            mask = apply_strict_mask_ppv(mask.astype(int))
     # ------------------------------------------------------------------
     # Apply edge trimming: zero out the half-beam border of the footprint
     # across all channels. This removes convolution-edge artefacts from
@@ -1241,7 +1128,7 @@ def run_fits(
     cubes      : pd.DataFrame — cube definitions from KeyHandler
     params     : dict         — target geometry from TargetHandler
     input_mask : pd.DataFrame, optional — mask definition from KeyHandler
-                (required if use_input_mask or use_fixed_window is set)
+                (required if use_input_mask or use_fixed_vel_mask is set)
     hfs_data   : pd.DataFrame or None, optional — hyperfine data from KeyHandler
                 (required if use_hfs_lines is set)
     """

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -965,13 +965,39 @@ def run_moments_ppv(
         if use_input:
             ext = _load_ppv_ext("input")
             if ext is not None:
-                mask_parts.append(ext)
+                if use_hfs_lines and hfs_data is not None:
+                    lines_hfs_names = list(set(hfs_data["hfs_name"]))
+                    ext_extended = ext.astype(int).copy()
+                    for line in line_names:
+                        if line in lines_hfs_names:
+                            ext_hfs = build_hfs_mask_ppv(
+                                ext.astype(float), line, hfs_data, delta_v_kms
+                            )
+                            if ext_hfs is not None:
+                                ext_extended = ext_extended | ext_hfs.astype(int)
+                                LOG.info(f"External input mask extended to HFS frequencies for {line}.")
+                    mask_parts.append(ext_extended)
+                else:
+                    mask_parts.append(ext)
                 LOG.info("Input mask included in PPV mask.")
 
         if use_window:
             ext = _load_ppv_ext("window")
             if ext is not None:
-                mask_parts.append(ext)
+                if use_hfs_lines and hfs_data is not None:
+                    lines_hfs_names = list(set(hfs_data["hfs_name"]))
+                    ext_extended = ext.astype(int).copy()
+                    for line in line_names:
+                        if line in lines_hfs_names:
+                            ext_hfs = build_hfs_mask_ppv(
+                                ext.astype(float), line, hfs_data, delta_v_kms
+                            )
+                            if ext_hfs is not None:
+                                ext_extended = ext_extended | ext_hfs.astype(int)
+                                LOG.info(f"External window mask extended to HFS frequencies for {line}.")
+                    mask_parts.append(ext_extended)
+                else:
+                    mask_parts.append(ext)
                 LOG.info("Velocity-window mask included in PPV mask.")
 
         if not mask_parts:

--- a/hexmaps/stage_fits.py
+++ b/hexmaps/stage_fits.py
@@ -775,51 +775,75 @@ def run_moments_ppv(
     """
     Compute and write PPV-native moment maps for every cube of *target*.
 
-    This function reproduces the mask-construction orchestration of
-    stage_products.run_products (ref_line selection, ref_line combination
-    modes, strict_mask, HFS extension, use_input_mask /
-    use_fixed_vel_mask) exactly, but operates on convolved PPV cubes
-    (get_convolved_ppv_cube) and computes moments with get_mom_maps_ppv
-    instead of working through the hex-grid .ecsv table.
-
-    Required inputs (raises FileNotFoundError if missing, per cube):
-      - the convolved PPV cube, either a previously saved save_cubes output or
-        (as a fallback) the raw input cube to convolve from scratch — see
-        get_convolved_ppv_cube.
-      - the overlay cube (for the WCS / spectral axis / footprint).
-
-    Parameters
-    ----------
-    target        : str
-    meta          : dict — from KeyHandler.meta
-    cubes         : pd.DataFrame — cube definitions from KeyHandler
-    input_mask    : pd.DataFrame — mask definition from KeyHandler
-    hfs_data      : pd.DataFrame or None — hyperfine data from KeyHandler
-    params        : dict — target geometry from TargetHandler
-    folder        : str — output directory for the moment FITS files
-    save_mask     : bool — if True, also write the PPV mask(s) used here to FITS
-    noise_mask_df : pd.DataFrame or None — noise velocity window table from
-                   KeyHandler.get_noise_mask(). When use_fixed_noise_mask is
-                   True and this DataFrame is non-empty, the RMS noise is
-                   estimated from channels within these windows rather than
-                   from channels outside the integration mask.
+    Mask construction mirrors stage_products.run_products exactly:
+    parse_ref_line decodes ref_line into mask_lines, use_individual,
+    use_input, use_window, and combinator; individual mode builds one
+    S/N mask per line applied only to that line; combined mode builds a
+    single master mask applied to all lines.  External masks (input,
+    window) are combined with the S/N mask(s) using the combinator.
     """
     # ------------------------------------------------------------------
-    # Unpack settings from meta
+    # Settings
     # ------------------------------------------------------------------
     ref_line_method  = meta.get("ref_line", "first")
     SN_processing    = meta.get("SN_processing", [2, 4])
     strict_mask      = meta.get("strict_mask", False)
     use_hfs_lines    = meta.get("use_hfs_lines", False)
+    fov_erosion_beams = float(meta.get("fov_erosion_beams", 0.5))
+    mom_calc = [
+        meta.get("mom_thresh", 5),
+        meta.get("conseq_channels", 3),
+        meta.get("mom2_method", "fwhm"),
+    ]
 
     line_names = [str(ln) for ln in cubes["line_name"]]
     n_lines    = len(line_names)
 
-    # Load and convolve all cubes up front (NaN masking applied per-cube later)
+    # ------------------------------------------------------------------
+    # Load overlay cube
+    # ------------------------------------------------------------------
+    data_dir     = meta.get("data_dir", "data/")
+    overlay_file = meta.get("overlay_file", "")
+    from os import path as _path
+    overlay_fname = (
+        _path.join(data_dir, overlay_file)
+        if target in overlay_file
+        else _path.join(data_dir, target + overlay_file)
+    )
+    ov_cube, ov_hdr = fits.getdata(overlay_fname, header=True)
+    ov_hdr, _ = _ensure_ms(ov_hdr.copy())
+
+    resolve_meta_resolution(target, params, meta, ov_hdr=ov_hdr, log=LOG)
+    target_res_as = meta["target_res"]
+
+    ov_footprint = np.any(np.isfinite(ov_cube), axis=0)
+    edge_mask = build_edge_mask(ov_footprint, ov_hdr, target_res_as, fov_erosion_beams)
+
+    # Velocity axis
+    unit_v = ov_hdr.get("CUNIT3", "m/s")
+    v0, dv, crpix = ov_hdr["CRVAL3"], ov_hdr["CDELT3"], ov_hdr["CRPIX3"]
+    n_chan  = ov_cube.shape[0]
+    vaxis   = (v0 + (np.arange(n_chan) - (crpix - 1)) * dv) * au.Unit(unit_v)
+    vaxis   = vaxis.to(au.km / au.s)
+    delta_v_kms = abs(dv * au.Unit(unit_v).to(au.km / au.s))
+
+    # Noise mask
+    use_fixed_noise_mask = meta.get("use_fixed_noise_mask", False)
+    _noise_mask_df = None
+    if use_fixed_noise_mask and noise_mask_df is not None and len(noise_mask_df) > 0:
+        _noise_mask_df = noise_mask_df
+        LOG.info(
+            f"Noise RMS will be estimated from {len(noise_mask_df)} "
+            "fixed velocity window(s)."
+        )
+
+    # ------------------------------------------------------------------
+    # Load and convolve all cubes
+    # ------------------------------------------------------------------
     cube_data = {}
     cube_hdrs = {}
     for _, row in cubes.iterrows():
-        name = str(row["line_name"]).upper()
+        name     = str(row["line_name"]).upper()
         raw_path = os.path.join(str(row["line_dir"]), target + str(row["line_ext"]))
         cube_hdrs[name] = fits.getheader(raw_path) if os.path.exists(raw_path) else {}
         data, _ = get_convolved_ppv_cube(
@@ -828,34 +852,27 @@ def run_moments_ppv(
         )
         cube_data[name] = data * au.Unit(str(row["line_unit"]))
 
-    # ref_line: the primary single line name used for vmean / shape fallback
+    # ref_line: primary line name for shape fallback
     line_names_upper = [ln.upper() for ln in line_names]
     ref_line_str = str(ref_line_method).split(",")[0].strip().upper()
     ref_line = (
-        ref_line_str
-        if ref_line_str in line_names_upper
-        else line_names_upper[0]
+        ref_line_str if ref_line_str in line_names_upper else line_names_upper[0]
     )
     if ref_line not in cube_data:
         LOG.warning(
             f"Nominal reference line {ref_line} not found; "
-            f"mask construction will use available cubes via parse_ref_line."
+            "mask construction will use available cubes via parse_ref_line."
         )
 
     # ------------------------------------------------------------------
-    # Mask construction — PPV-native equivalent of stage_products.
-    # parse_ref_line decodes ref_line into:
-    #   mask_lines  — cube lines for S/N masking (None=individual, []=none)
-    #   use_input   — include the external FITS input mask
-    #   use_window  — include the fixed velocity-window mask
-    #   combinator  — "AND" or "OR" (default "OR")
+    # Mask construction — mirrors stage_products.run_products exactly.
     # ------------------------------------------------------------------
     mask_lines, use_individual, use_input, use_window, combinator = parse_ref_line(
         ref_line_method, line_names
     )
 
-    # Helper: load an external PPV mask
     def _load_ppv_ext(kind):
+        """Load an external PPV mask ('input' or 'window')."""
         if kind == "window":
             if window_mask is None or len(window_mask) == 0:
                 LOG.error("ref_line contains 'window' but no window_mask is defined.")
@@ -883,22 +900,31 @@ def run_moments_ppv(
 
     # ---- individual mode ------------------------------------------------
     if use_individual:
-        LOG.info(f"Building individual PPV masks for {', '.join(line_names)}.")
-        for line in line_names:
-            if line not in cube_data:
+        LOG.info(f"Building individual PPV masks for {', '.join(mask_lines)}.")
+        for line in mask_lines:
+            ln_upper = line.upper()
+            if ln_upper not in cube_data:
                 continue
-            lm = construct_mask_ppv(cube_data[line].value, SN_processing).astype(int)
+            lm = construct_mask_ppv(cube_data[ln_upper].value, SN_processing).astype(int)
             if strict_mask:
                 lm = apply_strict_mask_ppv(lm)
-            # Apply external masks per-line if requested
-            for kind in ([("input")] if use_input else []) + ([("window")] if use_window else []):
-                ext = _load_ppv_ext(kind)
+
+            # Combine with external masks per-line
+            if use_input:
+                ext = _load_ppv_ext("input")
                 if ext is not None:
                     lm = (lm & ext) if combinator == "AND" else (lm | ext)
-                    LOG.info(f"Individual PPV mask for {line} {combinator} {kind} mask.")
-            ppv_line_masks[line] = lm
+                    LOG.info(f"PPV mask for {line} {combinator} input mask.")
+            if use_window:
+                ext = _load_ppv_ext("window")
+                if ext is not None:
+                    lm = (lm & ext) if combinator == "AND" else (lm | ext)
+                    LOG.info(f"PPV mask for {line} {combinator} window mask.")
+
+            ppv_line_masks[ln_upper] = lm
             LOG.info(f"Individual PPV mask built for {line}.")
-        # Union for edge-erosion and saved combined mask
+
+        # Union of per-line masks for edge-erosion and saved combined mask
         mask = np.zeros_like(next(iter(ppv_line_masks.values())), dtype=int)
         for lm in ppv_line_masks.values():
             mask = mask | np.asarray(lm).astype(int)
@@ -907,33 +933,31 @@ def run_moments_ppv(
     else:
         mask_parts = []
 
-        # S/N masks from cube lines
         if mask_lines:
             LOG.info(f"Building PPV velocity mask from: {', '.join(mask_lines)}.")
             for line in mask_lines:
-                if line not in cube_data:
+                ln_upper = line.upper()
+                if ln_upper not in cube_data:
                     LOG.warning(f"Mask line {line} not in loaded cubes; skipping.")
                     continue
-                mask_parts.append(
-                    construct_mask_ppv(cube_data[line].value, SN_processing).astype(int)
-                )
+                lm = construct_mask_ppv(
+                    cube_data[ln_upper].value, SN_processing
+                ).astype(int)
+                mask_parts.append(lm)
                 LOG.info(f"PPV mask includes {line}.")
 
-        # External input mask
         if use_input:
             ext = _load_ppv_ext("input")
             if ext is not None:
                 mask_parts.append(ext)
                 LOG.info("Input mask included in PPV mask.")
 
-        # Fixed velocity-window mask
         if use_window:
             ext = _load_ppv_ext("window")
             if ext is not None:
                 mask_parts.append(ext)
                 LOG.info("Velocity-window mask included in PPV mask.")
 
-        # Combine all parts
         if not mask_parts:
             LOG.warning("No PPV mask parts resolved; using empty mask.")
             mask = np.zeros(next(iter(cube_data.values())).shape, dtype=int)
@@ -947,31 +971,21 @@ def run_moments_ppv(
         if strict_mask:
             LOG.info("Applying strict spatial mask filter (PPV).")
             mask = apply_strict_mask_ppv(mask.astype(int))
+
     # ------------------------------------------------------------------
-    # Apply edge trimming: zero out the half-beam border of the footprint
-    # across all channels. This removes convolution-edge artefacts from
-    # both the moments and the saved mask FITS file.
-    # edge_mask is (ny, nx), broadcast across all channels via None axis.
+    # Edge trimming + NaN masking
     # ------------------------------------------------------------------
     mask = (np.asarray(mask) * edge_mask[None, :, :]).astype(int)
-
-    # Combined output NaN mask: True wherever the overlay has no data OR
-    # the pixel lies in the eroded edge strip. Applied consistently to all
-    # output files (moment maps, PPV mask cubes, and saved convolved cubes)
-    # so every pipeline output shares the same NaN pattern.
     out_nan_mask = ~(ov_footprint & edge_mask.astype(bool))
 
-    # Apply out_nan_mask to every in-memory cube BEFORE computing moments.
-    # This is critical: without it, the edge-strip pixels (which have biased
-    # values due to partial-beam convolution at the footprint boundary) would
-    # enter the RMS and moment calculations even though they are masked out
-    # in the integration mask. Setting them to NaN here ensures the moment
-    # estimators see a clean cube with no partial-beam contamination.
     for name in cube_data:
         cube_val = cube_data[name].value.copy()
         cube_val[:, out_nan_mask] = np.nan
         cube_data[name] = cube_val * cube_data[name].unit
 
+    # ------------------------------------------------------------------
+    # Save mask FITS files
+    # ------------------------------------------------------------------
     if save_mask:
         save_ppv_mask_to_fits(
             mask, ov_hdr, target, "mask", folder, out_nan_mask=out_nan_mask
@@ -992,17 +1006,17 @@ def run_moments_ppv(
                 )
 
     # ------------------------------------------------------------------
-    # Compute and write moments for every line.
+    # Compute and write moments per line
     # ------------------------------------------------------------------
     for jj, row in cubes.iterrows():
-        line_name = str(row["line_name"])
-        if line_name not in cube_data:
+        line_name  = str(row["line_name"])
+        ln_upper   = line_name.upper()
+        if ln_upper not in cube_data:
             continue
 
-        active_mask = mask
+        # Select the mask for this line
         if use_individual:
-            # Use this line's own mask, falling back to the union mask if absent.
-            active_mask = ppv_line_masks.get(line_name, mask)
+            active_mask = ppv_line_masks.get(ln_upper, mask)
         elif use_hfs_lines and hfs_data is not None:
             mask_hfs = build_hfs_mask_ppv(mask, line_name, hfs_data, delta_v_kms)
             if mask_hfs is not None:
@@ -1011,28 +1025,26 @@ def run_moments_ppv(
                 if save_mask and not np.array_equal(mask_hfs, mask):
                     hfs_mask_name = f"mask_{line_name.lower()}"
                     save_ppv_mask_to_fits(
-                        mask_hfs,
-                        ov_hdr,
-                        target,
-                        hfs_mask_name,
-                        folder,
-                        out_nan_mask=out_nan_mask,
+                        mask_hfs, ov_hdr, target, hfs_mask_name,
+                        folder, out_nan_mask=out_nan_mask,
                     )
                     LOG.info(
-                        f"PPV mask cube for {line_name} written to: {os.path.join(folder, f'{target}_{hfs_mask_name}.fits')}"
+                        f"PPV mask cube for {line_name} written to: "
+                        f"{os.path.join(folder, f'{target}_{hfs_mask_name}.fits')}"
                     )
+            else:
+                active_mask = mask
+        else:
+            active_mask = mask
 
         mom_maps = get_mom_maps_ppv(
-            cube_data[line_name],
+            cube_data[ln_upper],
             active_mask,
             vaxis,
             mom_calc,
             noise_mask=(
-                build_noise_mask(
-                    _noise_mask_df, vaxis, cube_data[line_name].shape
-                )
-                if _noise_mask_df is not None
-                else None
+                build_noise_mask(_noise_mask_df, vaxis, cube_data[ln_upper].shape)
+                if _noise_mask_df is not None else None
             ),
         )
 
@@ -1041,10 +1053,7 @@ def run_moments_ppv(
         line_unit = str(row["line_unit"])
 
         quantities = {
-            "mom0": (
-                mom_maps["mom0"],
-                "K km/s" if line_unit == "K" else f"{line_unit} km/s",
-            ),
+            "mom0":  (mom_maps["mom0"],     "K km/s" if line_unit == "K" else f"{line_unit} km/s"),
             "emom0": (mom_maps["mom0_err"], None),
             "mom1":  (mom_maps["mom1"],     "km/s"),
             "emom1": (mom_maps["mom1_err"], "km/s"),
@@ -1056,8 +1065,7 @@ def run_moments_ppv(
             "eew":   (mom_maps["ew_err"],   "km/s"),
         }
 
-        # out_nan_mask was computed once above, from ov_footprint & edge_mask.
-        _raw_hdr = cube_hdrs.get(line_name, {})
+        _raw_hdr = cube_hdrs.get(ln_upper, {})
         _restfrq = (
             (_raw_hdr.get("RESTFRQ") or _raw_hdr.get("RESTFREQ"))
             if _raw_hdr else None
@@ -1073,7 +1081,7 @@ def run_moments_ppv(
                 line_desc=line_desc,
                 object_name=target,
                 bmaj_as=target_res_as,
-                restfrq=None,   # 2D moment maps have no spectral axis
+                restfrq=None,
                 meta=meta,
             )
             res_suffix = meta.get("res_suffix", "27p0as")
@@ -1081,14 +1089,14 @@ def run_moments_ppv(
                 folder, f"{target}_{line_name}_{res_suffix}_{quantity}.fits"
             )
             data_out = (
-                arr.value.copy()
-                if hasattr(arr, "value")
+                arr.value.copy() if hasattr(arr, "value")
                 else np.asarray(arr, dtype=float).copy()
             )
             data_out[out_nan_mask] = np.nan
             fits.writeto(fname_fits, data=data_out, header=hdr_out, overwrite=True)
 
         LOG.info(f"Compute moment maps and write to file for line: {line_name}.")
+
 
 
 def run_fits(

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -51,7 +51,7 @@ SPEC_VAXIS_SHUFF   : shuffled velocity axis in km/s (n_pts × n_shuff_chan)
 
 import numpy as np
 import pandas as pd
-from astropy import units as u
+from astropy import units as au
 from astropy.stats import median_absolute_deviation
 from astropy.table import Table, Column
 
@@ -104,7 +104,7 @@ def construct_mask(ref_line, this_data, SN_processing):
         + (np.arange(n_chan) - (this_data.meta["SPEC_CRPIX"] - 1))
         * this_data.meta["SPEC_DELTAV"]
     )
-    line_vaxis = line_vaxis.to(u.km / u.s)
+    line_vaxis = line_vaxis.to(au.km / au.s)
 
     # Two-pass global MAD to estimate the noise floor
     rms = median_absolute_deviation(ref_line_data, axis=None, ignore_nan=True)
@@ -143,8 +143,8 @@ def construct_mask(ref_line, this_data, SN_processing):
         mask = ((mask + np.roll(mask, 1, 1) + np.roll(mask, -1, 1)) >= 1).astype(int)
 
     # Compute intensity-weighted mean velocity per sampling point
-    mask_q = mask * u.dimensionless_unscaled
-    line_vmean = np.zeros(n_pts) * np.nan * u.km / u.s
+    mask_q = mask * au.dimensionless_unscaled
+    line_vmean = np.zeros(n_pts) * np.nan * au.km / au.s
     for jj in range(n_pts):
         denom = np.nansum(ref_line_data[jj, :] * mask_q[jj, :])
         if denom != 0:
@@ -203,7 +203,7 @@ def _apply_strict_mask(mask, this_data):
                 continue
             dist_array = np.sqrt((ra - ra[n]) ** 2 + (dec - dec[n]) ** 2)
             idx_neigh = np.where(
-                abs(dist_array - sep) < 0.1 * this_data.meta["beam_as"].to(u.deg)
+                abs(dist_array - sep) < 0.1 * this_data.meta["beam_as"].to(au.deg)
             )
             labels_given = np.unique(mask_labels[idx_neigh])
             index = labels_given[labels_given > 0]
@@ -256,19 +256,19 @@ def _build_hfs_mask(mask, line_name, hfs_data, this_data):
 
     idx_cols = hfs_data["hfs_name"] == line_name
     restfreqs = [
-        f * u.Unit(str(u))
+        f * au.Unit(str(u))
         for f, u in zip(hfs_data["hfs_ref_freq"][idx_cols], hfs_data["unit"][idx_cols])
     ]
     hfs_freqs = [
-        f * u.Unit(str(u))
+        f * au.Unit(str(u))
         for f, u in zip(hfs_data["hfs_freq"][idx_cols], hfs_data["unit"][idx_cols])
     ]
 
-    v_ch = this_data.meta["SPEC_DELTAV"].to(u.km / u.s)
+    v_ch = this_data.meta["SPEC_DELTAV"].to(au.km / au.s)
     mask_hfs = np.copy(mask)
 
     for freq, restfreq in zip(hfs_freqs, restfreqs):
-        v_shift = freq.to(u.km / u.s, equivalencies=u.doppler_radio(restfreq))
+        v_shift = freq.to(au.km / au.s, equivalencies=au.doppler_radio(restfreq))
         shift_ch = int(np.rint(v_shift.value / v_ch.value))
 
         mask_shift = np.zeros_like(mask, dtype=float)
@@ -281,49 +281,8 @@ def _build_hfs_mask(mask, line_name, hfs_data, this_data):
 
         mask_hfs[mask_shift == 1] = 1
 
-    return mask_hfs * u.dimensionless_unscaled
+    return mask_hfs * au.dimensionless_unscaled
 
-# ============================================================================
-# Individual mask per line
-# ============================================================================
-# LN: CAN PROBABLY REMOVE THIS FUNCTION
-# def construct_individual_mask(line_names, this_data, SN_processing, use_hfs_lines=False, hfs_data=None, velocity_window=None):
-#     """
-#     Construct an individual mask for each spectral line. (will be used if ref_line_method == "self")
-#     """
-
-#     line_masks = {}
-#     line_vmeans = {}
-
-#     for line in line_names:
-
-#         mask, vmean, vaxis = construct_mask(line, this_data, SN_processing)
-
-#         ### COMMENT: this should happen after the combination with the external mask
-#         # special case for lines with HFS
-#         # if use_hfs_lines and hfs_data is not None:
-#         #     mask_hfs = _build_hfs_mask(mask.value, line, hfs_data, this_data)
-#             # if mask_hfs is not None:
-#             #     mask = mask_hfs
-
-#         # include v_window in masking
-#         # if velocity_window is not None:
-#         #     vmin, vmax = velocity_window
-#         #     # vaxis shape: (n_chan,)
-#         #     vmask = (vaxis >= vmin) & (vaxis <= vmax)
-#         #     # broadcast to (n_pix, n_chan)
-#         #     mask = mask * vmask
-
-#         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
-#             mask_line,
-#             unit=u.dimensionless_unscaled,
-#             description=f"Velocity-integration mask for {line}",
-#         )
-
-#         line_masks[line] = mask
-#         line_vmeans[line] = vmean
-
-#     return line_masks, line_vmeans
 
 # ============================================================================
 # Stage entry point
@@ -420,7 +379,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             )
             this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                 mask_line,
-                unit=u.dimensionless_unscaled,
+                unit=au.dimensionless_unscaled,
                 description=f"Velocity-integration mask for {line}",
             )
             if ref_line_vmean is None:
@@ -439,11 +398,11 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                         mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
                         mask_line = (
                             (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
-                        ) * u.dimensionless_unscaled
+                        ) * au.dimensionless_unscaled
                         # update line-specific mask in database
                         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                             mask_line,
-                            unit=u.dimensionless_unscaled,
+                            unit=au.dimensionless_unscaled,
                             description=f"Velocity-integration mask for {line}",
                         )
                     LOG.info(f"Individual masks {combinator} input mask.")
@@ -459,14 +418,35 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                         mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
                         mask_line = (
                             (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
-                        ) * u.dimensionless_unscaled                        
+                        ) * au.dimensionless_unscaled                        
                         # update line-specific mask in database
                         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                             mask_line,
-                            unit=u.dimensionless_unscaled,
+                            unit=au.dimensionless_unscaled,
                             description=f"Velocity-integration mask for {line}",
                         )
                     LOG.info(f"Individual masks {combinator} velocity-window mask.")
+
+        # HFS mask extension
+        lines_hfs = (
+            list(set(hfs_data["hfs_name"]))
+            if (use_hfs_lines and hfs_data is not None)
+            else []
+        )
+        if use_hfs_lines and hfs_data is not None:
+            for jj in range(n_lines):
+                if line_names[jj] in lines_hfs:
+                    LOG.info(f"Building HFS mask for {line_names[jj]}.")
+                    mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
+                    mask_line_hfs = _build_hfs_mask(
+                        mask_line, line_names[jj], hfs_data, this_data
+                    )
+                    if mask_line_hfs is not None:
+                        this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
+                            mask_line_hfs,
+                            unit=au.dimensionless_unscaled,
+                            description=f"HFS mask for {line_names[jj].upper()}",
+                        )
 
     # ---- combined mask mode ---------------------------------------------
     else:
@@ -482,7 +462,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                 )
                 this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                     mask_line,
-                    unit=u.dimensionless_unscaled,
+                    unit=au.dimensionless_unscaled,
                     description=f"Velocity-integration mask for {line}",
                 )
                 if ref_line_vmean is None:
@@ -525,12 +505,12 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
         if not mask_parts:
             LOG.warning("No mask parts resolved; using empty mask.")
             n_pts, n_chan = np.shape(this_data[f"SPEC_{ref_line.upper()}"])
-            mask = np.zeros((n_pts, n_chan), dtype=int) * u.dimensionless_unscaled
+            mask = np.zeros((n_pts, n_chan), dtype=int) * au.dimensionless_unscaled
         else:
             combined = mask_parts[0].copy()
             for part in mask_parts[1:]:
                 combined = (combined & part) if combinator == "AND" else (combined | part)
-            mask = combined * u.dimensionless_unscaled
+            mask = combined * au.dimensionless_unscaled
             if len(mask_parts) > 1:
                 LOG.info(
                     f"Combined {len(mask_parts)} mask(s) with {combinator}."
@@ -542,33 +522,34 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             mask = _apply_strict_mask(
                 np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int),
                 this_data,
-            ) * u.dimensionless_unscaled
+            ) * au.dimensionless_unscaled
 
         # Store the combined mask
         this_data["SPEC_MASK"] = Column(
             mask,
-            unit=u.dimensionless_unscaled,
+            unit=au.dimensionless_unscaled,
             description="Velocity-integration mask",
         )
-    # HFS mask extension
-    lines_hfs = (
-        list(set(hfs_data["hfs_name"]))
-        if (use_hfs_lines and hfs_data is not None)
-        else []
-    )
-    if use_hfs_lines and hfs_data is not None:
-        for jj in range(n_lines):
-            if line_names[jj] in lines_hfs:
-                LOG.info(f"Building HFS mask for {line_names[jj]}.")
-                mask_hfs = _build_hfs_mask(
-                    mask.value, line_names[jj], hfs_data, this_data
-                )
-                if mask_hfs is not None:
-                    this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
-                        mask_hfs,
-                        unit=u.dimensionless_unscaled,
-                        description=f"HFS mask for {line_names[jj].upper()}",
+
+        # HFS mask extension
+        lines_hfs = (
+            list(set(hfs_data["hfs_name"]))
+            if (use_hfs_lines and hfs_data is not None)
+            else []
+        )
+        if use_hfs_lines and hfs_data is not None:
+            for jj in range(n_lines):
+                if line_names[jj] in lines_hfs:
+                    LOG.info(f"Building HFS mask for {line_names[jj]}.")
+                    mask_hfs = _build_hfs_mask(
+                        mask.value, line_names[jj], hfs_data, this_data
                     )
+                    if mask_hfs is not None:
+                        this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
+                            mask_hfs,
+                            unit=au.dimensionless_unscaled,
+                            description=f"HFS mask for {line_names[jj].upper()}",
+                        )
 
     LOG.info(f"Mask(s) complete. Computing moments.")
 
@@ -582,25 +563,25 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
     #       column by direct assignment — doing this inside the loop causes the
     #       second line onward to fail silently.
     # ------------------------------------------------------------------
-    cdelt = shuff_axis[1] * u.m / u.s
+    cdelt = shuff_axis[1] * au.m / au.s
     naxis_shuff = int(shuff_axis[0])
-    new_vaxis = (cdelt * (np.arange(naxis_shuff) - naxis_shuff / 2)).to(u.km / u.s)
+    new_vaxis = (cdelt * (np.arange(naxis_shuff) - naxis_shuff / 2)).to(au.km / au.s)
 
     n_pts_total = len(this_data)
     _v0 = this_data.meta["SPEC_VCHAN0"]
     _dv = this_data.meta["SPEC_DELTAV"]
     _crpix = this_data.meta["SPEC_CRPIX"]
     _n_chan = np.shape(this_data["SPEC_" + line_names[0].upper()])[1]
-    _vaxis = (_v0 + (np.arange(_n_chan) - (_crpix - 1)) * _dv).to(u.km / u.s)
+    _vaxis = (_v0 + (np.arange(_n_chan) - (_crpix - 1)) * _dv).to(au.km / au.s)
 
     this_data["SPEC_VAXIS"] = Column(
         np.array([_vaxis] * n_pts_total),
-        unit=u.km / u.s,
+        unit=au.km / au.s,
         description="Velocity axis (km/s)",
     )
     this_data["SPEC_VAXIS_SHUFF"] = Column(
         np.array([new_vaxis] * n_pts_total),
-        unit=u.km / u.s,
+        unit=au.km / au.s,
         description="Shuffled velocity axis (km/s)",
     )
     this_data.meta["SPEC_VCHAN0_SHUFF"] = new_vaxis[0]
@@ -657,7 +638,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
         this_crpix = this_data.meta["SPEC_CRPIX"]
         this_vaxis = (
             this_v0 + (np.arange(n_chan_l) - (this_crpix - 1)) * this_deltav
-        ).to(u.km / u.s)
+        ).to(au.km / au.s)
 
         # Choose the appropriate mask for this line:
         # use_individual → each line has its own mask built from that line's data
@@ -668,7 +649,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             if use_hfs_lines and line_name in lines_hfs:
                 hfs_tag = f"SPEC_MASK_{line_name.upper()}"
                 active_mask = (
-                    this_data[hfs_tag] * u.Unit(1) if hfs_tag in this_data.keys() else mask
+                    this_data[hfs_tag] * au.Unit(1) if hfs_tag in this_data.keys() else mask
                 )
             else:
                 active_mask = mask

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -55,7 +55,7 @@ from astropy import units as u
 from astropy.stats import median_absolute_deviation
 from astropy.table import Table, Column
 
-from hexmaps.utils_table import shuffle, get_mom_maps, build_noise_mask, resolve_mask_lines, parse_ref_line
+from hexmaps.utils_table import shuffle, get_mom_maps, build_noise_mask, parse_ref_line
 
 from hexmaps.logger import get_logger
 
@@ -342,13 +342,11 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     # ------------------------------------------------------------------
     # Unpack settings from meta
     # ------------------------------------------------------------------
-    use_input_mask = meta.get("use_input_mask", False)
-    use_fixed_window = meta.get("use_fixed_window", False)
-    use_hfs_lines = meta.get("use_hfs_lines", False)
-    strict_mask = meta.get("strict_mask", False)
-    ref_line_method = meta.get("ref_line", "first")
-    SN_processing = meta.get("SN_processing", [2, 4])
-    velocity_window=meta.get("velocity_window", None)
+    ref_line_method  = meta.get("ref_line", "first")
+    SN_processing    = meta.get("SN_processing", [2, 4])
+    strict_mask      = meta.get("strict_mask", False)
+    use_hfs_lines    = meta.get("use_hfs_lines", False)
+    velocity_window  = meta.get("velocity_window", None)
     mom_calc = [
         meta.get("mom_thresh", 5),
         meta.get("conseq_channels", 3),
@@ -356,156 +354,160 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     ]
     shuff_axis = [meta.get("NAXIS_shuff", 200), meta.get("CDELT_SHUFF", 4000.0)]
 
-    this_data = Table.read(fname)
+    this_data  = Table.read(fname)
     line_names = [str(l) for l in cubes["line_name"]]
-    n_lines = len(line_names)
+    n_lines    = len(line_names)
 
-    # Determine the reference line (default: first cube in the list)
+    # ref_line: the first line in the list (used for vmean / shuffling fallback)
     ref_line = (
         ref_line_method
-        if ref_line_method in line_names
+        if isinstance(ref_line_method, str)
+        and ref_line_method in line_names
         else line_names[0]
     )
 
     n_chan = np.shape(this_data[f"SPEC_{ref_line.upper()}"])[1]
-
+    #   mask_lines  — cube lines for S/N masking (None=individual, []=none)
+    #   use_input   — whether to include the external input mask
+    #   use_window  — whether to include the fixed velocity-window mask
+    #   combinator  — "AND" or "OR" (default "OR")
+    #
+    # All requested masks are collected and combined with the combinator.
     # ------------------------------------------------------------------
-    # Mask construction
-    # ------------------------------------------------------------------
-    # parse_ref_line resolves:
-    #   mask_lines   — which cube lines to OR-combine for the primary mask
-    #                  (None signals individual mode)
-    #   combinations — list of (op, src) pairs from combination tokens:
-    #                  AND(input), OR(input), AND(window), OR(window)
-    # ------------------------------------------------------------------
-    mask_lines, combinations = parse_ref_line(ref_line_method, line_names)
+    mask_lines, use_input, use_window, combinator = parse_ref_line(
+        ref_line_method, line_names
+    )
 
-    if mask_lines is None:
-        # individual mode: build one mask per line
-        LOG.info(f"Building individual masks for {', '.join(line_names)}.")
-        line_masks, line_vmeans = construct_individual_mask(
-            line_names, this_data, SN_processing, use_hfs_lines, hfs_data, velocity_window
-        )
-
-    else:
-        # Build the combined S/N mask by looping over the resolved lines
-        LOG.info(f"Building velocity mask from: {', '.join(mask_lines)}.")
-        mask = None
-        ref_line_vmean = None
-        for line in mask_lines:
-            mask_line, vmean_line, _ = construct_mask(line, this_data, SN_processing)
-            this_data[f"SPEC_MASK_{line.upper()}"] = Column(
-                mask_line,
-                unit=u.dimensionless_unscaled,
-                description=f"Velocity-integration mask for {line}",
-            )
-            if mask is None:
-                mask = mask_line
-                ref_line_vmean = vmean_line
-                LOG.info(f"Building mask for line: {line}.")
-            else:
-                mask = (
-                    mask.value.astype(int) | mask_line.value.astype(int)
-                ) * u.dimensionless_unscaled
-                LOG.info(f"Adding line to mask: {line}.")
-
-        # Optional strict spatial connectivity filter
-        if strict_mask:
-            LOG.info(f"Applying strict spatial mask filter.")
-            mask_arr = _apply_strict_mask(mask.value.astype(int), this_data)
-            mask = mask_arr * u.dimensionless_unscaled
-
-        # Store the primary mask before any external combination
-        this_data["SPEC_MASK"] = Column(
-            mask,
-            unit=u.dimensionless_unscaled,
-            description="Velocity-integration mask (used for all integrated products)",
-        )
-
-    # ------------------------------------------------------------------
-    # Apply combination tokens AND(input), OR(input), AND(window), OR(window).
-    # ------------------------------------------------------------------
-    def _get_ext_mask(src):
-        """Fetch the external mask array for 'input' or 'window' source."""
-        if len(input_mask) == 0:
-            LOG.error(f"Combination token requires a mask but none is defined in config.")
-            return None
-        tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+    # Helper: fetch the external mask array from the table column
+    def _get_ext_col(tag):
         if tag not in this_data.colnames:
-            LOG.warning(f"External mask column {tag} not found in table; skipping.")
+            LOG.warning(f"External mask column {tag} not found; skipping.")
             return None
         ext = this_data[tag]
         del this_data[tag]
         return np.asarray(ext.value if hasattr(ext, "value") else ext).astype(int)
 
-    handled_srcs = set()
-    for op, src in combinations:
-        if src == "input" and not use_input_mask:
-            LOG.warning(f"{op}(input) in ref_line but use_input_mask = false — skipping.")
-            continue
-        if src == "window" and not use_fixed_window:
-            LOG.warning(f"{op}(window) in ref_line but use_fixed_window = false — skipping.")
-            continue
-        ext_arr = _get_ext_mask(src)
-        if ext_arr is None:
-            continue
-        handled_srcs.add(src)
-        LOG.info(f"Combining primary mask {op} {src} mask.")
-        if mask_lines is None:
-            for ln in line_masks:
-                lm = np.asarray(
-                    line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
-                ).astype(int)
-                line_masks[ln] = (
-                    (lm & ext_arr) if op == "AND" else (lm | ext_arr)
-                ) * u.dimensionless_unscaled
-        else:
-            cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
-            mask = (
-                (cur & ext_arr) if op == "AND" else (cur | ext_arr)
-            ) * u.dimensionless_unscaled
-            this_data["SPEC_MASK"] = Column(
-                mask, unit=u.dimensionless_unscaled,
-                description=f"Velocity-integration mask ({op} {src} mask)",
+    # ---- individual mode ------------------------------------------------
+    if mask_lines is None:
+        LOG.info(f"Building individual masks for {', '.join(line_names)}.")
+        line_masks, line_vmeans = construct_individual_mask(
+            line_names, this_data, SN_processing,
+            use_hfs_lines, hfs_data, velocity_window,
+        )
+        # Apply external masks per-line if requested
+        if use_input or use_window:
+            ext_tag = (
+                f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+                if len(input_mask) > 0 else None
             )
+            if use_input and ext_tag:
+                ext_arr = _get_ext_col(ext_tag)
+                if ext_arr is not None:
+                    for ln in line_masks:
+                        lm = np.asarray(
+                            line_masks[ln].value
+                            if hasattr(line_masks[ln], "value") else line_masks[ln]
+                        ).astype(int)
+                        line_masks[ln] = (
+                            (lm & ext_arr) if combinator == "AND" else (lm | ext_arr)
+                        ) * u.dimensionless_unscaled
+                    LOG.info(f"Individual masks {combinator} input mask.")
+            if use_window and ext_tag:
+                ext_arr = _get_ext_col(ext_tag)
+                if ext_arr is not None:
+                    for ln in line_masks:
+                        lm = np.asarray(
+                            line_masks[ln].value
+                            if hasattr(line_masks[ln], "value") else line_masks[ln]
+                        ).astype(int)
+                        line_masks[ln] = (
+                            (lm & ext_arr) if combinator == "AND" else (lm | ext_arr)
+                        ) * u.dimensionless_unscaled
+                    LOG.info(f"Individual masks {combinator} velocity-window mask.")
 
-    # Legacy flags: apply AND if the corresponding src was not already
-    # handled by an explicit combination token.
-    if use_input_mask and "input" not in handled_srcs:
-        ext_arr = _get_ext_mask("input")
-        if ext_arr is not None:
-            if mask_lines is None:
-                for ln in line_masks:
-                    lm = np.asarray(
-                        line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
-                    ).astype(int)
-                    line_masks[ln] = (lm & ext_arr) * u.dimensionless_unscaled
-            else:
-                cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
-                mask = (cur & ext_arr) * u.dimensionless_unscaled
-                this_data["SPEC_MASK"] = Column(
-                    mask, unit=u.dimensionless_unscaled,
-                    description="Velocity-integration mask (AND input mask)",
-                )
-            LOG.info("Input mask AND-combined (legacy use_input_mask flag).")
+    # ---- combined mask mode ---------------------------------------------
+    else:
+        # Collect all requested mask arrays
+        mask_parts = []
 
-    if use_fixed_window and "window" not in handled_srcs:
-        ext_arr = _get_ext_mask("window")
-        if ext_arr is not None:
-            if mask_lines is None:
-                for ln in line_masks:
-                    lm = np.asarray(
-                        line_masks[ln].value if hasattr(line_masks[ln], "value") else line_masks[ln]
-                    ).astype(int)
-                    line_masks[ln] = (lm & ext_arr) * u.dimensionless_unscaled
-            else:
-                cur = np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int)
-                mask = (cur & ext_arr) * u.dimensionless_unscaled
-                this_data["SPEC_MASK"] = Column(
-                    mask, unit=u.dimensionless_unscaled,
-                    description="Velocity-integration mask (AND window velocity mask)",
+        # S/N masks from cube lines
+        ref_line_vmean = None
+        if mask_lines:
+            LOG.info(f"Building velocity mask from: {', '.join(mask_lines)}.")
+            for line in mask_lines:
+                mask_line, vmean_line, _ = construct_mask(
+                    line, this_data, SN_processing
                 )
-            LOG.info("Fixed velocity mask AND-combined (legacy use_fixed_window flag).")
+                this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                    mask_line,
+                    unit=u.dimensionless_unscaled,
+                    description=f"Velocity-integration mask for {line}",
+                )
+                if ref_line_vmean is None:
+                    ref_line_vmean = vmean_line
+                mask_parts.append(
+                    np.asarray(
+                        mask_line.value
+                        if hasattr(mask_line, "value") else mask_line
+                    ).astype(int)
+                )
+
+        # External input mask
+        if use_input:
+            if len(input_mask) == 0:
+                LOG.error("ref_line contains 'input' but no mask is defined in config.")
+            else:
+                ext_tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+                ext_arr = _get_ext_col(ext_tag)
+                if ext_arr is not None:
+                    mask_parts.append(ext_arr)
+                    LOG.info("Input mask included.")
+
+        # Fixed velocity-window mask
+        if use_window:
+            if len(input_mask) == 0:
+                LOG.error("ref_line contains 'window' but no mask is defined in config.")
+            else:
+                ext_tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+                ext_arr = _get_ext_col(ext_tag)
+                if ext_arr is not None:
+                    mask_parts.append(ext_arr)
+                    LOG.info("Velocity-window mask included.")
+                    # Use ref_line vmean for shuffling when only window provided
+                    if ref_line_vmean is None:
+                        _, ref_line_vmean, _ = construct_mask(
+                            line_names[0], this_data, SN_processing
+                        )
+
+        # Combine all parts with the combinator
+        if not mask_parts:
+            LOG.warning("No mask parts resolved; using empty mask.")
+            n_pts, n_chan = np.shape(this_data[f"SPEC_{ref_line.upper()}"])
+            mask = np.zeros((n_pts, n_chan), dtype=int) * u.dimensionless_unscaled
+        else:
+            combined = mask_parts[0].copy()
+            for part in mask_parts[1:]:
+                combined = (combined & part) if combinator == "AND" else (combined | part)
+            mask = combined * u.dimensionless_unscaled
+            if len(mask_parts) > 1:
+                LOG.info(
+                    f"Combined {len(mask_parts)} mask(s) with {combinator}."
+                )
+
+        # Optional strict spatial connectivity filter
+        if strict_mask:
+            LOG.info("Applying strict spatial mask filter.")
+            mask = _apply_strict_mask(
+                np.asarray(mask.value if hasattr(mask, "value") else mask).astype(int),
+                this_data,
+            ) * u.dimensionless_unscaled
+
+        # Store the combined mask
+        this_data["SPEC_MASK"] = Column(
+            mask,
+            unit=u.dimensionless_unscaled,
+            description="Velocity-integration mask",
+        )
     # HFS mask extension
     lines_hfs = (
         list(set(hfs_data["hfs_name"]))

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -385,7 +385,11 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             if ref_line_vmean is None:
                 ref_line_vmean = vmean_line
 
-        # Apply external masks per-line if requested
+        # Apply external masks per-line if requested.
+        # When use_hfs_lines is True and a line has HFS satellite entries,
+        # the external mask is first duplicated and shifted to each satellite
+        # frequency before combining, so the external mask covers the same
+        # spectral extent as the per-line S/N mask.
         if use_input:
             ext_tag = _input_tag()
             if ext_tag is None:
@@ -394,12 +398,20 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
                     for line in mask_lines:
-                        # get line-specific mask and combine with external input mask
+                        ext_line = ext_arr
+                        if use_hfs_lines and hfs_data is not None:
+                            ext_hfs = _build_hfs_mask(
+                                ext_arr.astype(float), line, hfs_data, this_data
+                            )
+                            if ext_hfs is not None:
+                                ext_line = np.asarray(
+                                    ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
+                                ).astype(int)
+                                LOG.info(f"External input mask shifted to HFS frequencies for {line}.")
                         mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
                         mask_line = (
-                            (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
+                            (mask_line & ext_line) if combinator == "AND" else (mask_line | ext_line)
                         ) * au.dimensionless_unscaled
-                        # update line-specific mask in database
                         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                             mask_line,
                             unit=au.dimensionless_unscaled,
@@ -414,12 +426,20 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
                     for line in mask_lines:
-                        # get line-specific mask and combine with external input mask
+                        ext_line = ext_arr
+                        if use_hfs_lines and hfs_data is not None:
+                            ext_hfs = _build_hfs_mask(
+                                ext_arr.astype(float), line, hfs_data, this_data
+                            )
+                            if ext_hfs is not None:
+                                ext_line = np.asarray(
+                                    ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
+                                ).astype(int)
+                                LOG.info(f"External window mask shifted to HFS frequencies for {line}.")
                         mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
                         mask_line = (
-                            (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
-                        ) * au.dimensionless_unscaled                        
-                        # update line-specific mask in database
+                            (mask_line & ext_line) if combinator == "AND" else (mask_line | ext_line)
+                        ) * au.dimensionless_unscaled
                         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
                             mask_line,
                             unit=au.dimensionless_unscaled,
@@ -427,26 +447,6 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                         )
                     LOG.info(f"Individual masks {combinator} velocity-window mask.")
 
-        # HFS mask extension
-        lines_hfs = (
-            list(set(hfs_data["hfs_name"]))
-            if (use_hfs_lines and hfs_data is not None)
-            else []
-        )
-        if use_hfs_lines and hfs_data is not None:
-            for jj in range(n_lines):
-                if line_names[jj] in lines_hfs:
-                    LOG.info(f"Building HFS mask for {line_names[jj]}.")
-                    mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
-                    mask_line_hfs = _build_hfs_mask(
-                        mask_line, line_names[jj], hfs_data, this_data
-                    )
-                    if mask_line_hfs is not None:
-                        this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
-                            mask_line_hfs,
-                            unit=au.dimensionless_unscaled,
-                            description=f"HFS mask for {line_names[jj].upper()}",
-                        )
 
     # ---- combined mask mode ---------------------------------------------
     else:

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -485,27 +485,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    if use_hfs_lines and hfs_data is not None:
-                        lines_hfs = list(set(hfs_data["hfs_name"]))
-                        ext_extended = ext_arr.astype(int).copy()
-                        for line in line_names:
-                            if line in lines_hfs:
-                                ext_hfs = _build_hfs_mask(
-                                    ext_arr.astype(float), line, hfs_data, this_data
-                                )
-                                if ext_hfs is not None:
-                                    ext_extended = ext_extended | np.asarray(
-                                        ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
-                                    ).astype(int)                                    
-                                    this_data[f"SPEC_MASK_{line.upper()}"] = Column(
-                                        ext_hfs,
-                                        unit=au.dimensionless_unscaled,
-                                        description=f"HFS mask for {line.upper()}",
-                                    )
-                                    LOG.info(f"External input mask extended to HFS frequencies for {line}.")
-                        mask_parts.append(ext_extended)
-                    else:
-                        mask_parts.append(ext_arr)
+                    mask_parts.append(ext_arr)
                     LOG.info("Input mask included.")
 
         # Fixed velocity-window mask (pre-sampled onto hex grid by stage_regrid).
@@ -517,27 +497,7 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    if use_hfs_lines and hfs_data is not None:
-                        lines_hfs = list(set(hfs_data["hfs_name"]))
-                        ext_extended = ext_arr.astype(int).copy()
-                        for line in line_names:
-                            if line in lines_hfs:
-                                ext_hfs = _build_hfs_mask(
-                                    ext_arr.astype(float), line, hfs_data, this_data
-                                )
-                                if ext_hfs is not None:
-                                    ext_extended = ext_extended | np.asarray(
-                                        ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
-                                    ).astype(int)
-                                    this_data[f"SPEC_MASK_{line.upper()}"] = Column(
-                                        ext_hfs,
-                                        unit=au.dimensionless_unscaled,
-                                        description=f"HFS mask for {line.upper()}",
-                                    )
-                                    LOG.info(f"External window mask extended to HFS frequencies for {line}.")
-                        mask_parts.append(ext_extended)
-                    else:
-                        mask_parts.append(ext_arr)
+                    mask_parts.append(ext_arr)
                     LOG.info("Velocity-window mask included.")
                     # Use ref_line vmean for shuffling when only window provided
                     if ref_line_vmean is None:
@@ -576,25 +536,25 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
         )
 
         # HFS mask extension
-        if not use_input and not use_window:
-            lines_hfs = (
-                list(set(hfs_data["hfs_name"]))
-                if (use_hfs_lines and hfs_data is not None)
-                else []
-            )
-            if use_hfs_lines and hfs_data is not None:
-                for jj in range(n_lines):
-                    if line_names[jj] in lines_hfs:
-                        LOG.info(f"Building HFS mask for {line_names[jj]}.")
-                        mask_hfs = _build_hfs_mask(
-                            mask.value, line_names[jj], hfs_data, this_data
+        # if not use_input and not use_window:
+        lines_hfs = (
+            list(set(hfs_data["hfs_name"]))
+            if (use_hfs_lines and hfs_data is not None)
+            else []
+        )
+        if use_hfs_lines and hfs_data is not None:
+            for jj in range(n_lines):
+                if line_names[jj] in lines_hfs:
+                    LOG.info(f"Building HFS mask for {line_names[jj]}.")
+                    mask_hfs = _build_hfs_mask(
+                        mask.value, line_names[jj], hfs_data, this_data
+                    )
+                    if mask_hfs is not None:
+                        this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
+                            mask_hfs,
+                            unit=au.dimensionless_unscaled,
+                            description=f"HFS mask for {line_names[jj].upper()}",
                         )
-                        if mask_hfs is not None:
-                            this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
-                                mask_hfs,
-                                unit=au.dimensionless_unscaled,
-                                description=f"HFS mask for {line_names[jj].upper()}",
-                            )
 
     LOG.info(f"Mask(s) complete. Computing moments.")
 

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -286,42 +286,52 @@ def _build_hfs_mask(mask, line_name, hfs_data, this_data):
 # ============================================================================
 # Individual mask per line
 # ============================================================================
-def construct_individual_mask(line_names, this_data, SN_processing, use_hfs_lines=False, hfs_data=None, velocity_window=None):
-    """
-    Construct an individual mask for each spectral line. (will be used if ref_line_method == "self")
-    """
+# LN: CAN PROBABLY REMOVE THIS FUNCTION
+# def construct_individual_mask(line_names, this_data, SN_processing, use_hfs_lines=False, hfs_data=None, velocity_window=None):
+#     """
+#     Construct an individual mask for each spectral line. (will be used if ref_line_method == "self")
+#     """
 
-    line_masks = {}
-    line_vmeans = {}
+#     line_masks = {}
+#     line_vmeans = {}
 
-    for line in line_names:
+#     for line in line_names:
 
-        mask, vmean, vaxis = construct_mask(line, this_data, SN_processing)
-        # special case for lines with HFS
-        if use_hfs_lines and hfs_data is not None:
-            mask_hfs = _build_hfs_mask(mask.value, line, hfs_data, this_data)
+#         mask, vmean, vaxis = construct_mask(line, this_data, SN_processing)
 
-            if mask_hfs is not None:
-                mask = mask_hfs
-        # include v_window in masking
-        if velocity_window is not None:
-            vmin, vmax = velocity_window
-            # vaxis shape: (n_chan,)
-            vmask = (vaxis >= vmin) & (vaxis <= vmax)
-            # broadcast to (n_pix, n_chan)
-            mask = mask * vmask
+#         ### COMMENT: this should happen after the combination with the external mask
+#         # special case for lines with HFS
+#         # if use_hfs_lines and hfs_data is not None:
+#         #     mask_hfs = _build_hfs_mask(mask.value, line, hfs_data, this_data)
+#             # if mask_hfs is not None:
+#             #     mask = mask_hfs
 
-        line_masks[line] = mask
-        line_vmeans[line] = vmean
+#         # include v_window in masking
+#         # if velocity_window is not None:
+#         #     vmin, vmax = velocity_window
+#         #     # vaxis shape: (n_chan,)
+#         #     vmask = (vaxis >= vmin) & (vaxis <= vmax)
+#         #     # broadcast to (n_pix, n_chan)
+#         #     mask = mask * vmask
 
-    return line_masks, line_vmeans
+#         this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+#             mask_line,
+#             unit=u.dimensionless_unscaled,
+#             description=f"Velocity-integration mask for {line}",
+#         )
+
+#         line_masks[line] = mask
+#         line_vmeans[line] = vmean
+
+#     return line_masks, line_vmeans
 
 # ============================================================================
 # Stage entry point
 # ============================================================================
 
 
-def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df=None):
+def run_products(target, fname, meta, cubes, input_mask, hfs_data,
+                 window_mask=None, noise_mask_df=None):
     """
     Process all spectra for *target*: mask, moments, shuffle.
 
@@ -367,67 +377,99 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
     )
 
     n_chan = np.shape(this_data[f"SPEC_{ref_line.upper()}"])[1]
-    #   mask_lines  — cube lines for S/N masking (None=individual, []=none)
+    #   mask_lines  — cube lines for S/N masking
     #   use_input   — whether to include the external input mask
     #   use_window  — whether to include the fixed velocity-window mask
     #   combinator  — "AND" or "OR" (default "OR")
     #
     # All requested masks are collected and combined with the combinator.
     # ------------------------------------------------------------------
-    mask_lines, use_input, use_window, combinator = parse_ref_line(
+    mask_lines, use_individual, use_input, use_window, combinator = parse_ref_line(
         ref_line_method, line_names
     )
 
     # Helper: fetch the external mask array from the table column
     def _get_ext_col(tag):
+        """Fetch and remove a pre-sampled mask column from the table."""
         if tag not in this_data.colnames:
-            LOG.warning(f"External mask column {tag} not found; skipping.")
+            LOG.warning(f"External mask column {tag} not found in table; skipping.")
             return None
         ext = this_data[tag]
         del this_data[tag]
         return np.asarray(ext.value if hasattr(ext, "value") else ext).astype(int)
 
-    # ---- individual mode ------------------------------------------------
-    if mask_lines is None:
-        LOG.info(f"Building individual masks for {', '.join(line_names)}.")
-        line_masks, line_vmeans = construct_individual_mask(
-            line_names, this_data, SN_processing,
-            use_hfs_lines, hfs_data, velocity_window,
+    def _input_tag():
+        return (
+            f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
+            if input_mask is not None and len(input_mask) > 0 else None
         )
-        # Apply external masks per-line if requested
-        if use_input or use_window:
-            ext_tag = (
-                f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
-                if len(input_mask) > 0 else None
+
+    def _window_tag():
+        return (
+            f'SPEC_{str(window_mask["mask_name"].iloc[0]).upper()}'
+            if window_mask is not None and len(window_mask) > 0 else None
+        )
+
+    # ---- individual mode ------------------------------------------------
+    if use_individual:
+        LOG.info(f"Building individual masks for {', '.join(mask_lines)}.")
+        ref_line_vmean = None
+        for line in mask_lines:
+            mask_line, vmean_line, _ = construct_mask(
+                line, this_data, SN_processing
             )
-            if use_input and ext_tag:
+            this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                mask_line,
+                unit=u.dimensionless_unscaled,
+                description=f"Velocity-integration mask for {line}",
+            )
+            if ref_line_vmean is None:
+                ref_line_vmean = vmean_line
+
+        # Apply external masks per-line if requested
+        if use_input:
+            ext_tag = _input_tag()
+            if ext_tag is None:
+                LOG.error("ref_line contains 'input' but no input_mask is defined.")
+            else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    for ln in line_masks:
-                        lm = np.asarray(
-                            line_masks[ln].value
-                            if hasattr(line_masks[ln], "value") else line_masks[ln]
-                        ).astype(int)
-                        line_masks[ln] = (
-                            (lm & ext_arr) if combinator == "AND" else (lm | ext_arr)
+                    for line in mask_lines:
+                        # get line-specific mask and combine with external input mask
+                        mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
+                        mask_line = (
+                            (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
                         ) * u.dimensionless_unscaled
+                        # update line-specific mask in database
+                        this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                            mask_line,
+                            unit=u.dimensionless_unscaled,
+                            description=f"Velocity-integration mask for {line}",
+                        )
                     LOG.info(f"Individual masks {combinator} input mask.")
-            if use_window and ext_tag:
+        if use_window:
+            ext_tag = _window_tag()
+            if ext_tag is None:
+                LOG.error("ref_line contains 'window' but no window_mask is defined.")
+            else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    for ln in line_masks:
-                        lm = np.asarray(
-                            line_masks[ln].value
-                            if hasattr(line_masks[ln], "value") else line_masks[ln]
-                        ).astype(int)
-                        line_masks[ln] = (
-                            (lm & ext_arr) if combinator == "AND" else (lm | ext_arr)
-                        ) * u.dimensionless_unscaled
+                    for line in mask_lines:
+                        # get line-specific mask and combine with external input mask
+                        mask_line = this_data[f"SPEC_MASK_{line.upper()}"].astype(int)
+                        mask_line = (
+                            (mask_line & ext_arr) if combinator == "AND" else (mask_line | ext_arr)
+                        ) * u.dimensionless_unscaled                        
+                        # update line-specific mask in database
+                        this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                            mask_line,
+                            unit=u.dimensionless_unscaled,
+                            description=f"Velocity-integration mask for {line}",
+                        )
                     LOG.info(f"Individual masks {combinator} velocity-window mask.")
 
     # ---- combined mask mode ---------------------------------------------
     else:
-        # Collect all requested mask arrays
         mask_parts = []
 
         # S/N masks from cube lines
@@ -452,23 +494,23 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
                     ).astype(int)
                 )
 
-        # External input mask
+        # External FITS input mask (pre-sampled onto hex grid by stage_regrid)
         if use_input:
-            if len(input_mask) == 0:
-                LOG.error("ref_line contains 'input' but no mask is defined in config.")
+            ext_tag = _input_tag()
+            if ext_tag is None:
+                LOG.error("ref_line contains 'input' but no input_mask is defined.")
             else:
-                ext_tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
                     mask_parts.append(ext_arr)
                     LOG.info("Input mask included.")
 
-        # Fixed velocity-window mask
+        # Fixed velocity-window mask (pre-sampled onto hex grid by stage_regrid)
         if use_window:
-            if len(input_mask) == 0:
-                LOG.error("ref_line contains 'window' but no mask is defined in config.")
+            ext_tag = _window_tag()
+            if ext_tag is None:
+                LOG.error("ref_line contains 'window' but no window_mask is defined.")
             else:
-                ext_tag = f'SPEC_{str(input_mask["mask_name"].iloc[0]).upper()}'
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
                     mask_parts.append(ext_arr)
@@ -617,11 +659,11 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
             this_v0 + (np.arange(n_chan_l) - (this_crpix - 1)) * this_deltav
         ).to(u.km / u.s)
 
-        # Choose the appropriate mask for this line
-        # (individual mode: per-line mask; all others: combined mask)
-        if ref_line_method == "individual":
-            active_mask = line_masks[line_name]
-            line_vmean = line_vmeans[line_name]
+        # Choose the appropriate mask for this line:
+        # use_individual → each line has its own mask built from that line's data
+        # otherwise      → all lines share the combined master mask
+        if use_individual:
+            active_mask = this_data[f"SPEC_MASK_{line_name.upper()}"].astype(int)
         else:
             if use_hfs_lines and line_name in lines_hfs:
                 hfs_tag = f"SPEC_MASK_{line_name.upper()}"
@@ -630,7 +672,8 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data, noise_mask_df
                 )
             else:
                 active_mask = mask
-            line_vmean = ref_line_vmean
+        # LN: can think about implementing option to use the line-specific mean velocities
+        line_vmean = ref_line_vmean
             
         # Compute moment maps; use the noise channel mask if available,
         # otherwise fall back to inverting the integration mask.

--- a/hexmaps/stage_products.py
+++ b/hexmaps/stage_products.py
@@ -474,7 +474,10 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
                     ).astype(int)
                 )
 
-        # External FITS input mask (pre-sampled onto hex grid by stage_regrid)
+        # External FITS input mask (pre-sampled onto hex grid by stage_regrid).
+        # When use_hfs_lines is active, the external mask is first extended to
+        # cover the HFS satellite frequencies of every HFS-capable line, then
+        # combined into mask_parts so the master mask covers all components.
         if use_input:
             ext_tag = _input_tag()
             if ext_tag is None:
@@ -482,10 +485,31 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    mask_parts.append(ext_arr)
+                    if use_hfs_lines and hfs_data is not None:
+                        lines_hfs = list(set(hfs_data["hfs_name"]))
+                        ext_extended = ext_arr.astype(int).copy()
+                        for line in line_names:
+                            if line in lines_hfs:
+                                ext_hfs = _build_hfs_mask(
+                                    ext_arr.astype(float), line, hfs_data, this_data
+                                )
+                                if ext_hfs is not None:
+                                    ext_extended = ext_extended | np.asarray(
+                                        ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
+                                    ).astype(int)                                    
+                                    this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                                        ext_hfs,
+                                        unit=au.dimensionless_unscaled,
+                                        description=f"HFS mask for {line.upper()}",
+                                    )
+                                    LOG.info(f"External input mask extended to HFS frequencies for {line}.")
+                        mask_parts.append(ext_extended)
+                    else:
+                        mask_parts.append(ext_arr)
                     LOG.info("Input mask included.")
 
-        # Fixed velocity-window mask (pre-sampled onto hex grid by stage_regrid)
+        # Fixed velocity-window mask (pre-sampled onto hex grid by stage_regrid).
+        # Same HFS extension logic as for the input mask above.
         if use_window:
             ext_tag = _window_tag()
             if ext_tag is None:
@@ -493,7 +517,27 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
             else:
                 ext_arr = _get_ext_col(ext_tag)
                 if ext_arr is not None:
-                    mask_parts.append(ext_arr)
+                    if use_hfs_lines and hfs_data is not None:
+                        lines_hfs = list(set(hfs_data["hfs_name"]))
+                        ext_extended = ext_arr.astype(int).copy()
+                        for line in line_names:
+                            if line in lines_hfs:
+                                ext_hfs = _build_hfs_mask(
+                                    ext_arr.astype(float), line, hfs_data, this_data
+                                )
+                                if ext_hfs is not None:
+                                    ext_extended = ext_extended | np.asarray(
+                                        ext_hfs.value if hasattr(ext_hfs, "value") else ext_hfs
+                                    ).astype(int)
+                                    this_data[f"SPEC_MASK_{line.upper()}"] = Column(
+                                        ext_hfs,
+                                        unit=au.dimensionless_unscaled,
+                                        description=f"HFS mask for {line.upper()}",
+                                    )
+                                    LOG.info(f"External window mask extended to HFS frequencies for {line}.")
+                        mask_parts.append(ext_extended)
+                    else:
+                        mask_parts.append(ext_arr)
                     LOG.info("Velocity-window mask included.")
                     # Use ref_line vmean for shuffling when only window provided
                     if ref_line_vmean is None:
@@ -532,24 +576,25 @@ def run_products(target, fname, meta, cubes, input_mask, hfs_data,
         )
 
         # HFS mask extension
-        lines_hfs = (
-            list(set(hfs_data["hfs_name"]))
-            if (use_hfs_lines and hfs_data is not None)
-            else []
-        )
-        if use_hfs_lines and hfs_data is not None:
-            for jj in range(n_lines):
-                if line_names[jj] in lines_hfs:
-                    LOG.info(f"Building HFS mask for {line_names[jj]}.")
-                    mask_hfs = _build_hfs_mask(
-                        mask.value, line_names[jj], hfs_data, this_data
-                    )
-                    if mask_hfs is not None:
-                        this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
-                            mask_hfs,
-                            unit=au.dimensionless_unscaled,
-                            description=f"HFS mask for {line_names[jj].upper()}",
+        if not use_input and not use_window:
+            lines_hfs = (
+                list(set(hfs_data["hfs_name"]))
+                if (use_hfs_lines and hfs_data is not None)
+                else []
+            )
+            if use_hfs_lines and hfs_data is not None:
+                for jj in range(n_lines):
+                    if line_names[jj] in lines_hfs:
+                        LOG.info(f"Building HFS mask for {line_names[jj]}.")
+                        mask_hfs = _build_hfs_mask(
+                            mask.value, line_names[jj], hfs_data, this_data
                         )
+                        if mask_hfs is not None:
+                            this_data[f"SPEC_MASK_{line_names[jj].upper()}"] = Column(
+                                mask_hfs,
+                                unit=au.dimensionless_unscaled,
+                                description=f"HFS mask for {line_names[jj].upper()}",
+                            )
 
     LOG.info(f"Mask(s) complete. Computing moments.")
 

--- a/hexmaps/stage_regrid.py
+++ b/hexmaps/stage_regrid.py
@@ -700,7 +700,7 @@ def sample_mask(in_data, ra_samp, dec_samp, in_hdr=None, target_hdr=None):
 # ============================================================================
 
 
-def run_regrid(target, params, meta, maps, cubes, input_mask):
+def run_regrid(target, params, meta, maps, cubes, input_mask, window_mask=None):
     """
     Convolve and sample all maps and cubes for *target*.
 
@@ -922,45 +922,50 @@ def run_regrid(target, params, meta, maps, cubes, input_mask):
         LOG.info(f"Cube {cube['line_name']} sampled successfully.")
 
     # ------------------------------------------------------------------
-    # Optional external mask
+    # Optional external masks — sampled onto the hex grid
     # ------------------------------------------------------------------
-    if len(input_mask) > 0:
-        use_fixed = meta.get("use_fixed_vel_mask", False)
-
-        if use_fixed:
-            # Build a binary mask from a fixed velocity window
-            mask_unit = input_mask["mask_unit"].iloc[0]
-            mask_start = float(input_mask["mask_start"].iloc[0]) * au.Unit(mask_unit)
-            mask_end = float(input_mask["mask_end"].iloc[0]) * au.Unit(mask_unit)
-            unit_v = ov_hdr.get("CUNIT3", "m/s")
-            v0, dv, crpix = ov_hdr["CRVAL3"], ov_hdr["CDELT3"], ov_hdr["CRPIX3"]
-            vaxis = (v0 + (np.arange(n_chan) - (crpix - 1)) * dv) * au.Unit(unit_v)
-            vaxis = vaxis.to(au.Unit(mask_unit))
-            spec_mask = np.zeros((n_pts, n_chan))
-            spec_mask[:, (vaxis >= mask_start) & (vaxis <= mask_end)] = 1.0
-            LOG.info(f"Fixed velocity mask applied " f"({mask_start} to {mask_end}).")
+    # input_mask: external FITS file mask
+    if input_mask is not None and len(input_mask) > 0:
+        mask_file = path.join(
+            str(input_mask["mask_dir"].iloc[0]),
+            target + str(input_mask["mask_ext"].iloc[0]),
+        )
+        if not path.exists(mask_file):
+            LOG.error(f"Input mask file not found: {mask_file}")
         else:
-            # Sample an external FITS mask file
-            mask_file = path.join(
-                str(input_mask["mask_dir"].iloc[0]),
-                target + str(input_mask["mask_ext"].iloc[0]),
+            _mask_label = "SPEC_" + str(input_mask["mask_name"].iloc[0]).upper()
+            input_headers[_mask_label] = fits.getheader(mask_file)
+            spec_mask, _ = sample_mask(
+                mask_file, samp_ra, samp_dec, target_hdr=ov_hdr
             )
-            if not path.exists(mask_file):
-                LOG.error(f"Mask file not found: {mask_file}")
-                spec_mask = np.zeros((n_pts, n_chan))
-            else:
-                _mask_label = "SPEC_" + str(input_mask["mask_name"].iloc[0]).upper()
-                input_headers[_mask_label] = fits.getheader(mask_file)
-                spec_mask, _ = sample_mask(
-                    mask_file, samp_ra, samp_dec, target_hdr=ov_hdr
-                )
-                LOG.info(f"External mask sampled.")
+            tag = "SPEC_" + str(input_mask["mask_name"].iloc[0]).upper()
+            this_data[tag] = Column(
+                spec_mask,
+                unit=au.dimensionless_unscaled,
+                description=str(input_mask["mask_desc"].iloc[0]),
+            )
+            LOG.info(f"External input mask sampled ({tag}).")
 
-        tag = "SPEC_" + str(input_mask["mask_name"].iloc[0]).upper()
+    # window_mask: fixed velocity-window mask built from the spectral axis
+    if window_mask is not None and len(window_mask) > 0:
+        mask_unit  = window_mask["mask_unit"].iloc[0]
+        mask_start = float(window_mask["mask_start"].iloc[0]) * au.Unit(mask_unit)
+        mask_end   = float(window_mask["mask_end"].iloc[0])   * au.Unit(mask_unit)
+        unit_v = ov_hdr.get("CUNIT3", "m/s")
+        v0, dv, crpix = ov_hdr["CRVAL3"], ov_hdr["CDELT3"], ov_hdr["CRPIX3"]
+        vaxis = (v0 + (np.arange(n_chan) - (crpix - 1)) * dv) * au.Unit(unit_v)
+        vaxis = vaxis.to(au.Unit(mask_unit))
+        spec_mask = np.zeros((n_pts, n_chan))
+        spec_mask[:, (vaxis >= mask_start) & (vaxis <= mask_end)] = 1.0
+        tag = "SPEC_" + str(window_mask["mask_name"].iloc[0]).upper()
         this_data[tag] = Column(
             spec_mask,
             unit=au.dimensionless_unscaled,
-            description=str(input_mask["mask_desc"].iloc[0]),
+            description=str(window_mask["mask_desc"].iloc[0]),
+        )
+        LOG.info(
+            f"Fixed velocity-window mask sampled "
+            f"({mask_start} to {mask_end}, {tag})."
         )
 
     # ------------------------------------------------------------------

--- a/hexmaps/templates/config.txt
+++ b/hexmaps/templates/config.txt
@@ -94,16 +94,16 @@ spire250,  SPIRE 250 um,      MJy/sr,  _spire250_gauss21.fits,  data/
 
 # ---- mask ----
 # Example file mask (comment out if unused):
-# co_mask, CO signal mask, _co_mask.fits, data/
+input_mask = co_mask, CO signal mask, _co_mask.fits, data/
 #
 # Example fixed-velocity mask (comment out if unused):
-#vel_mask, Fixed velocity window, -100, 100, km/s
+window_mask = window_mask, Fixed velocity window, 400, 600, km/s
 
 # Example noise velocity windows (comment out if unused):
 # Specify one or more line-free velocity ranges for noise (RMS) estimation.
 # Multiple windows are combined (OR) into a single noise channel mask.
-#noise_mask, Noise window (blue), -200, -100, km/s
-#noise_mask, Noise window (red),   100,  200, km/s
+noise_mask = noise_mask, Noise window (blue),   0,  400, km/s
+noise_mask = noise_mask, Noise window (red),  600,  800, km/s
 
 
 # -----------------------------------------------------------------------------
@@ -133,38 +133,40 @@ CDELT_SHUFF = 4000.0
 
 
 [masking]
-# Reference line for mask construction:
-#   first        - use the first line in the cube list above
-#   <LINE_NAME>  - use that specific line (case-insensitive)
-#   all          - use all lines
-#   n            - use first n lines
-#   individual   - compute one mask per line and apply individually
+# Reference line for mask construction.
+# A comma-separated list of tokens controls which masks are built and
+# how they are combined.
 #
-# Combination tokens (comma-separated, append to any keyword above):
-#   AND(input)   - AND-combine the ref_line mask with the input mask
-#   OR(input)    - OR-combine the ref_line mask with the input mask
-#   AND(fixed)   - AND-combine the ref_line mask with the fixed velocity mask
-#   OR(fixed)    - OR-combine the ref_line mask with the fixed velocity mask
+# Line-selection tokens (S/N mask from cube data):
+#   first        - first cube in the cube list (default)
+#   <LINE_NAME>  - a specific named line (case-insensitive)
+#   all          - all cubes
+#   n            - first n cubes
+#   individual   - one independent mask per cube, applied per-line
+#
+# External-mask tokens (additional masks to include):
+#   input        - external FITS mask (defined as a file row in [mask] table)
+#   window       - fixed velocity-window mask (vel_mask row in [mask] table)
+#
+# Combinator token (how all masks are combined; default: OR):
+#   OR           - include a sightline if it passes ANY mask (default)
+#   AND          - include a sightline only if it passes ALL masks
 #
 # Examples:
-#   ref_line = 12co21, AND(input)     -> 12co21 S/N mask AND input mask
-#   ref_line = first, OR(fixed)       -> first-line mask OR fixed window
-#   ref_line = all, AND(input)
-ref_line         = first
+#   ref_line = first                  # S/N mask from first cube
+#   ref_line = 12co21                 # S/N mask from 12co21
+#   ref_line = first, input           # OR of first-cube mask and input mask
+#   ref_line = 12co21, input, AND     # 12co21 mask AND input mask
+#   ref_line = first, window, AND     # first-cube mask AND velocity window
+#   ref_line = all, input, window     # OR of all-cube + input + window masks
+#   ref_line = individual             # one mask per line
+ref_line = first
 
 # Signal-to-noise thresholds for the two-step mask: [low, high]
 SN_processing = 2, 4
 
 # If true, apply a strict spatial consistency check on the mask
 strict_mask = false
-
-# Use an external mask FITS file defined in the [mask] table above.
-# The external mask is AND-combined with the ref_line-based mask:
-# only pixels valid in BOTH are retained.
-use_input_mask = false
-
-# Use a fixed velocity window defined in the [mask] table above
-use_fixed_vel_mask = false
 
 # Use explicit velocity windows (noise_mask rows in the [mask] table) for
 # noise (RMS) estimation instead of using channels outside the signal mask.

--- a/hexmaps/templates/config.txt
+++ b/hexmaps/templates/config.txt
@@ -135,10 +135,21 @@ CDELT_SHUFF = 4000.0
 [masking]
 # Reference line for mask construction:
 #   first        - use the first line in the cube list above
-#   <LINE_NAME>  - use that specific line
+#   <LINE_NAME>  - use that specific line (case-insensitive)
 #   all          - use all lines
 #   n            - use first n lines
-#   individual   - use individual mask per line
+#   individual   - compute one mask per line and apply individually
+#
+# Combination tokens (comma-separated, append to any keyword above):
+#   AND(input)   - AND-combine the ref_line mask with the input mask
+#   OR(input)    - OR-combine the ref_line mask with the input mask
+#   AND(fixed)   - AND-combine the ref_line mask with the fixed velocity mask
+#   OR(fixed)    - OR-combine the ref_line mask with the fixed velocity mask
+#
+# Examples:
+#   ref_line = 12co21, AND(input)     -> 12co21 S/N mask AND input mask
+#   ref_line = first, OR(fixed)       -> first-line mask OR fixed window
+#   ref_line = all, AND(input)
 ref_line         = first
 
 # Signal-to-noise thresholds for the two-step mask: [low, high]
@@ -147,7 +158,9 @@ SN_processing = 2, 4
 # If true, apply a strict spatial consistency check on the mask
 strict_mask = false
 
-# Use an external mask FITS file defined in the [mask] table above
+# Use an external mask FITS file defined in the [mask] table above.
+# The external mask is AND-combined with the ref_line-based mask:
+# only pixels valid in BOTH are retained.
 use_input_mask = false
 
 # Use a fixed velocity window defined in the [mask] table above

--- a/hexmaps/utils_fits.py
+++ b/hexmaps/utils_fits.py
@@ -35,7 +35,7 @@ import copy
 import warnings
 import numpy as np
 from pathlib import Path
-from astropy import units as u
+from astropy import units as au
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales
@@ -59,7 +59,7 @@ warnings.filterwarnings("ignore")
 # ============================================================================
 
 
-def get_beam_arcsec(fits_path: str, log=None) -> u.Quantity:
+def get_beam_arcsec(fits_path: str, log=None) -> au.Quantity:
     """
     Return the beam major axis (BMAJ) in arcseconds from a FITS header.
 
@@ -88,7 +88,7 @@ def get_beam_arcsec(fits_path: str, log=None) -> u.Quantity:
     if "BMAJ" not in hdr:
         log.error(f"BMAJ not found in header of {fits_path}")
         raise KeyError(f"BMAJ not found in header of {fits_path}")
-    return (hdr["BMAJ"] * u.deg).to(u.arcsec)
+    return (hdr["BMAJ"] * au.deg).to(au.arcsec)
 
 
 def read_fits_cube(fits_path: str, log=None):
@@ -607,12 +607,12 @@ def _get_pixel_scale(hdr, tol=0.1, log=None):
     log = log or _DEFAULT_LOG
     w = WCS(hdr)
     scales = proj_plane_pixel_scales(w)
-    px_dx = scales[0] * u.deg
-    px_dy = scales[1] * u.deg
-    if abs(px_dx - px_dy) > tol * u.arcsec:
+    px_dx = scales[0] * au.deg
+    px_dy = scales[1] * au.deg
+    if abs(px_dx - px_dy) > tol * au.arcsec:
         log.warning(
             f"Pixel scale differs in X and Y: "
-            f"{px_dx.to(u.arcsec):.3f} vs {px_dy.to(u.arcsec):.3f}. "
+            f"{px_dx.to(au.arcsec):.3f} vs {px_dy.to(au.arcsec):.3f}. "
             "Using geometric mean."
         )
         return np.sqrt(px_dx * px_dy).value

--- a/hexmaps/utils_table.py
+++ b/hexmaps/utils_table.py
@@ -506,127 +506,215 @@ def build_noise_mask(noise_mask_df, vaxis, shape):
 
 def parse_ref_line(ref_line_method, line_names):
     """
-    Parse the ``ref_line`` config value into masking lines and optional
-    combination directives.
+    Parse the ``ref_line`` config value into a structured specification.
 
-    In addition to the existing line-selection keywords (``first``,
-    ``all``, ``n``, ``individual``, or named lines), the ``ref_line``
-    value may contain one or more **combination tokens** as
-    comma-separated extra items:
+    The value is a **comma-separated list** of tokens belonging to three
+    strictly defined categories:
 
-    ``AND(input)``
-        AND-combine the ref_line mask with the external input mask
-        (defined in the ``[mask]`` table with ``use_input_mask = true``).
-    ``OR(input)``
-        OR-combine the ref_line mask with the external input mask.
-    ``AND(window)``
-        AND-combine the ref_line mask with the fixed velocity-window mask
-        (defined in the ``[mask]`` table with ``use_fixed_window = true``).
-    ``OR(window)``
-        OR-combine the ref_line mask with the fixed velocity-window mask.
+    **Combinator token** — exactly one, optional (default ``OR``):
 
-    Combination tokens are stripped from the token list before line
-    resolution so they do not interfere with line-name matching.
+    ``AND``
+        All selected masks must be True for a pixel to be included.
+    ``OR``
+        Any selected mask being True is sufficient (default).
 
-    Examples
-    --------
-    ``ref_line = 12co21, AND(input)``
-        Build the mask from 12co21, then AND with the input mask.
-    ``ref_line = first, OR(window)``
-        Build the mask from the first line, then OR with the fixed window.
-    ``ref_line = all, AND(input), AND(window)``
-        Union of all line masks, ANDed with both the input and window masks.
+    **External-mask tokens** — zero or more:
+
+    ``input``
+        Include the external FITS input mask (a file-mask row in the
+        ``# ---- mask ----`` table).
+    ``window``
+        Include the fixed velocity-window mask (a ``vel_mask`` row in
+        the ``# ---- mask ----`` table).
+
+    **Line-selection tokens** — exactly one, mandatory unless ``input``
+    and/or ``window`` are given without any line token:
+
+    ``first``
+        S/N mask from the first line in the cube list.
+    ``all``
+        S/N mask from the OR-union of all lines in the cube list.
+    ``<n>`` (positive integer)
+        S/N mask from the first *n* lines in the cube list.
+    ``individual``
+        Build and apply one independent S/N mask per line.
+    ``<LINE_NAME>`` (one or more comma-separated line names)
+        S/N mask from the specified named line(s), matched
+        case-insensitively against the cube list.  If a name is not
+        found in the cube list a ``ValueError`` is raised.
+
+    If no line-selection token is provided alongside ``input`` / ``window``
+    the function returns an empty ``mask_lines`` list (no S/N mask).
+    If no token of any recognised kind is found a ``ValueError`` is raised.
 
     Parameters
     ----------
     ref_line_method : str or int
         Raw value of the ``ref_line`` config key.
     line_names : list of str
-        All cube line names (typically lowercase) from the config.
+        All cube line names in the order they appear in the config.
 
     Returns
     -------
     mask_lines : list of str (uppercase) or None
-        Lines to OR-combine for the primary mask, or ``None`` for
-        ``individual`` mode.
-    combinations : list of (str, str)
-        Zero or more ``(operation, source)`` pairs describing how to
-        combine the primary mask with external masks.
-        *operation* is ``"AND"`` or ``"OR"``.
-        *source* is ``"input"`` or ``"window"``.
+        Lines to combine for the primary S/N mask.
+        ``None`` means *individual* mode.
+        ``[]`` means no S/N mask requested (only external masks).
+    use_input  : bool — include the external input mask.
+    use_window : bool — include the fixed velocity-window mask.
+    combinator : str  — ``"AND"`` or ``"OR"``.
+
+    Raises
+    ------
+    ValueError
+        If ``line_names`` is empty, if an unknown token is encountered, or
+        if a named line is not found in ``line_names``.
+
+    Examples
+    --------
+    ``ref_line = first``                 → mask from first line (OR combinator)
+    ``ref_line = 12co21``                → mask from 12co21
+    ``ref_line = 12co21, 12co10``        → OR of 12co21 and 12co10 masks
+    ``ref_line = all``                   → OR of all line masks
+    ``ref_line = 2``                     → OR of first 2 line masks
+    ``ref_line = individual``            → one mask per line, applied per-line
+    ``ref_line = first, input``          → OR of first-line S/N mask + input mask
+    ``ref_line = 12co21, input, AND``    → 12co21 S/N mask AND input mask
+    ``ref_line = first, window, AND``    → first-line S/N mask AND velocity window
+    ``ref_line = input, window``         → OR of input mask + velocity window
+    ``ref_line = input``                 → only input mask (no S/N mask)
     """
     if not line_names:
         raise ValueError("parse_ref_line: line_names is empty.")
 
-    # --------------- extract combination tokens first -------------------
-    _COMBO_TOKENS = {"AND(INPUT)", "OR(INPUT)", "AND(FIXED)", "OR(FIXED)"}
-    raw_tokens  = [t.strip() for t in str(ref_line_method).split(",")]
-    combo_tokens = [t for t in raw_tokens if t.upper() in _COMBO_TOKENS]
-    line_tokens  = [t for t in raw_tokens if t.upper() not in _COMBO_TOKENS]
+    # ----------------------------------------------------------------
+    # Step 1: tokenise
+    # ----------------------------------------------------------------
+    raw_tokens = [t.strip() for t in str(ref_line_method).split(",") if t.strip()]
+    if not raw_tokens:
+        raise ValueError(
+            f"parse_ref_line: ref_line is empty. "
+            f"Provide at least one token (e.g. 'first', a line name, "
+            f"'input', or 'window')."
+        )
 
-    combinations = []
-    for tok in combo_tokens:
-        tok_up = tok.upper()
-        op     = tok_up.split("(")[0]          # "AND" or "OR"
-        src    = tok_up[len(op)+1:-1].lower()  # "input" or "window"
-        combinations.append((op, src))
+    # ----------------------------------------------------------------
+    # Step 2: classify each token
+    # ----------------------------------------------------------------
+    # Known special tokens (case-insensitive)
+    _COMBINATOR_TOKENS = {"AND", "OR"}
+    _EXTERNAL_TOKENS   = {"input", "window"}
+    _KEYWORD_TOKENS    = {"first", "all", "individual"}
 
-    # Rejoin the non-combo tokens for the existing resolution logic
-    ref_core = ", ".join(line_tokens).strip().strip(",").strip()
-    if not ref_core:
-        ref_core = "first"
+    combinator = "OR"
+    use_input  = False
+    use_window = False
+    line_tokens = []          # tokens that are line names or keywords / int
 
-    # --------------- resolve line tokens --------------------------------
-    # Individual mode
-    if ref_core.lower() == "individual":
-        return None, combinations
+    for raw in raw_tokens:
 
-    # all
-    if ref_core.lower() == "all":
-        return line_names, combinations
+        if raw in _COMBINATOR_TOKENS:
+            combinator = raw
+            continue
 
-    # integer → first n lines
-    try:
-        n = int(ref_core)
-        n = max(1, min(n, len(line_names)))
-        return line_names[:n], combinations
-    except (ValueError, TypeError):
-        pass
+        if raw == "input":
+            use_input = True
+            continue
 
-    # "first"
-    if ref_core.lower() == "first":
-        return [line_names[0]], combinations
+        if raw == "window":
+            use_window = True
+            continue
 
-    # Named line(s)
-    candidates = [p.strip().upper() for p in ref_core.split(",")]
-    resolved = []
-    for c in candidates:
-        if c in line_names:
-            resolved.append(c)
-        else:
-            import logging as _logging
-            _logging.getLogger("hexmaps").warning(
-                f"parse_ref_line: '{c}' not found in cube list {line_names}; skipping."
-            )
-    if resolved:
-        return resolved, combinations
+        if raw in _KEYWORD_TOKENS:
+            line_tokens.append(raw)
+            continue
 
-    # Fallback
-    import logging as _logging
-    _logging.getLogger("hexmaps").warning(
-        f"parse_ref_line: unrecognised ref_line value '{ref_line_method}'; "
-        f"falling back to first line '{line_names[0]}'."
+        # Positive integer?
+        try:
+            n = int(raw)
+        except ValueError:
+            n = None
+
+        if n is not None:
+            if n < 1:
+                raise ValueError(
+                    f"parse_ref_line: integer token must be ≥ 1, got '{raw}'."
+                )
+            line_tokens.append(raw)
+            continue
+
+        # Named line from the cube list?
+        if raw in line_names:
+            line_tokens.append(raw)
+            continue
+
+        # Nothing matched — hard error
+        raise ValueError(
+            f"parse_ref_line: unrecognised token '{raw}'. "
+            f"Expected one of: AND, OR, input, window, first, all, individual, "
+            f"a positive integer, or a line name from the cube list {line_names}."
+        )
+
+    # ----------------------------------------------------------------
+    # Step 3: resolve the line-selection tokens
+    # ----------------------------------------------------------------
+    # Validate: at most ONE line-selection mode is allowed.
+    # (multiple named lines are fine; mixing FIRST with a line name is not)
+    keyword_found = [t for t in line_tokens if t in _KEYWORD_TOKENS]
+    named_found   = [t for t in line_tokens if t in line_names]
+    int_found     = []
+    for t in line_tokens:
+        try:
+            int_found.append(int(t))
+        except ValueError:
+            pass
+
+    # Check for conflicting selection modes
+    n_modes = (
+        (1 if "individual" in keyword_found else 0)
+        + (1 if "all" in keyword_found else 0)
+        + (1 if "first" in keyword_found else 0)
+        + (1 if int_found else 0)
+        + (1 if named_found else 0)
     )
-    return [line_names[0]], combinations
+    if n_modes > 1:
+        raise ValueError(
+            f"parse_ref_line: conflicting line-selection tokens in '{ref_line_method}'. "
+            f"Provide exactly one of: first, all, individual, an integer, or line name(s)."
+        )
 
+    if not line_tokens:
+        # Only external tokens provided — no S/N mask
+        if not use_input and not use_window:
+            raise ValueError(
+                f"parse_ref_line: no valid token found in '{ref_line_method}'. "
+                f"Provide at least one of: first, all, individual, an integer, "
+                f"a line name, 'input', or 'window'."
+            )
+        mask_lines = []
 
-def resolve_mask_lines(ref_line_method, line_names):
-    """
-    Backwards-compatible wrapper around :func:`parse_ref_line`.
+    elif "individual" in line_tokens:
+        mask_lines = None
 
-    Returns only the mask-line list (ignores combination tokens).
-    New code should call :func:`parse_ref_line` directly.
-    """
-    mask_lines, _ = parse_ref_line(ref_line_method, line_names)
-    return mask_lines
+    elif "all" in line_tokens:
+        mask_lines = line_names
 
+    elif "first" in line_tokens:
+        mask_lines = [line_names[0]]
+
+    elif int_found:
+        n = int_found[0]
+        n = max(1, min(n, len(line_names)))
+        mask_lines = line_names[:n]
+
+    else:
+        # Named lines
+        mask_lines = named_found   # already validated above
+
+    print(f"parse_ref_line: mask_lines={mask_lines}, \
+          use_input={use_input}, \
+          use_window={use_window}, \
+          combinator={combinator}"
+          )
+
+    return mask_lines, use_input, use_window, combinator

--- a/hexmaps/utils_table.py
+++ b/hexmaps/utils_table.py
@@ -508,112 +508,89 @@ def parse_ref_line(ref_line_method, line_names):
     """
     Parse the ``ref_line`` config value into a structured specification.
 
-    The value is a **comma-separated list** of tokens belonging to three
-    strictly defined categories:
+    The value is a comma-separated list of tokens in three categories:
 
-    **Combinator token** — exactly one, optional (default ``OR``):
+    **Combinator token** (optional, default ``OR``):
+        ``AND`` — all masks must be True.
+        ``OR``  — any mask being True is sufficient (default).
 
-    ``AND``
-        All selected masks must be True for a pixel to be included.
-    ``OR``
-        Any selected mask being True is sufficient (default).
+    **External-mask tokens** (zero or more):
+        ``input``  — include the external FITS input mask.
+        ``window`` — include the fixed velocity-window mask.
 
-    **External-mask tokens** — zero or more:
-
-    ``input``
-        Include the external FITS input mask (a file-mask row in the
-        ``# ---- mask ----`` table).
-    ``window``
-        Include the fixed velocity-window mask (a ``vel_mask`` row in
-        the ``# ---- mask ----`` table).
-
-    **Line-selection tokens** — exactly one, mandatory unless ``input``
-    and/or ``window`` are given without any line token:
-
-    ``first``
-        S/N mask from the first line in the cube list.
-    ``all``
-        S/N mask from the OR-union of all lines in the cube list.
-    ``<n>`` (positive integer)
-        S/N mask from the first *n* lines in the cube list.
-    ``individual``
-        Build and apply one independent S/N mask per line.
-    ``<LINE_NAME>`` (one or more comma-separated line names)
-        S/N mask from the specified named line(s), matched
-        case-insensitively against the cube list.  If a name is not
-        found in the cube list a ``ValueError`` is raised.
-
-    If no line-selection token is provided alongside ``input`` / ``window``
-    the function returns an empty ``mask_lines`` list (no S/N mask).
-    If no token of any recognised kind is found a ``ValueError`` is raised.
+    **Line-selection token** (exactly one, mandatory unless only
+    ``input``/``window`` are given):
+        ``first``        — S/N mask from the first line in the cube list.
+        ``all``          — S/N mask from all lines in the cube list.
+        ``<n>``          — S/N mask from the first *n* lines (integer ≥ 1).
+        ``individual``   — one independent S/N mask per line, each applied
+                           only to that line's moments.  External masks are
+                           still combined with each per-line mask.
+        ``<LINE_NAME>``  — one or more named lines from the cube list,
+                           matched case-insensitively.
 
     Parameters
     ----------
     ref_line_method : str or int
-        Raw value of the ``ref_line`` config key.
-    line_names : list of str
-        All cube line names in the order they appear in the config.
+    line_names : list of str  — cube line names from the config.
 
     Returns
     -------
-    mask_lines : list of str (uppercase) or None
-        Lines to combine for the primary S/N mask.
-        ``None`` means *individual* mode.
-        ``[]`` means no S/N mask requested (only external masks).
+    mask_lines     : list of str
+        Line names to build S/N masks from (original case).
+        Empty list means no S/N mask requested (only external masks).
+        For ``individual`` mode this is the full cube list;
+        ``use_individual`` tells the caller how to apply them.
+    use_individual : bool
+        True  → build one S/N mask per line, apply it only to that line.
+        False → combine all masks into a single master mask for every line.
     use_input  : bool — include the external input mask.
     use_window : bool — include the fixed velocity-window mask.
     combinator : str  — ``"AND"`` or ``"OR"``.
 
     Raises
     ------
-    ValueError
-        If ``line_names`` is empty, if an unknown token is encountered, or
-        if a named line is not found in ``line_names``.
+    ValueError — empty input, unknown token, conflicting selection modes,
+                 or a named line not found in the cube list.
 
     Examples
     --------
-    ``ref_line = first``                 → mask from first line (OR combinator)
-    ``ref_line = 12co21``                → mask from 12co21
-    ``ref_line = 12co21, 12co10``        → OR of 12co21 and 12co10 masks
-    ``ref_line = all``                   → OR of all line masks
-    ``ref_line = 2``                     → OR of first 2 line masks
-    ``ref_line = individual``            → one mask per line, applied per-line
-    ``ref_line = first, input``          → OR of first-line S/N mask + input mask
-    ``ref_line = 12co21, input, AND``    → 12co21 S/N mask AND input mask
-    ``ref_line = first, window, AND``    → first-line S/N mask AND velocity window
-    ``ref_line = input, window``         → OR of input mask + velocity window
-    ``ref_line = input``                 → only input mask (no S/N mask)
+    ``first``                 master mask from the first line
+    ``12co21``                master mask from 12co21
+    ``12co21, 12co10``        master mask: OR of both S/N masks
+    ``all``                   master mask: OR of all S/N masks
+    ``2``                     master mask: OR of first-2 S/N masks
+    ``individual``            per-line masks, applied per-line
+    ``individual, input, AND``  per-line mask AND input mask
+    ``first, input``          master mask: OR of first-line S/N + input
+    ``12co21, input, AND``    master mask: 12co21 S/N AND input
+    ``first, window, AND``    master mask: first-line S/N AND window
+    ``input``                 only input mask (no S/N mask)
     """
     if not line_names:
         raise ValueError("parse_ref_line: line_names is empty.")
 
-    # ----------------------------------------------------------------
-    # Step 1: tokenise
-    # ----------------------------------------------------------------
+    # --- tokenise -------------------------------------------------------
     raw_tokens = [t.strip() for t in str(ref_line_method).split(",") if t.strip()]
     if not raw_tokens:
         raise ValueError(
-            f"parse_ref_line: ref_line is empty. "
-            f"Provide at least one token (e.g. 'first', a line name, "
-            f"'input', or 'window')."
+            "parse_ref_line: ref_line is empty. "
+            "Provide at least one token (e.g. 'first', a line name, "
+            "'input', or 'window')."
         )
 
-    # ----------------------------------------------------------------
-    # Step 2: classify each token
-    # ----------------------------------------------------------------
-    # Known special tokens (case-insensitive)
-    _COMBINATOR_TOKENS = {"AND", "OR"}
-    _EXTERNAL_TOKENS   = {"input", "window"}
-    _KEYWORD_TOKENS    = {"first", "all", "individual"}
+    # --- classify -------------------------------------------------------
+    upper_to_orig = {ln.upper(): ln for ln in line_names}
 
-    combinator = "OR"
-    use_input  = False
-    use_window = False
-    line_tokens = []          # tokens that are line names or keywords / int
+    combinator     = "OR"
+    use_input      = False
+    use_window     = False
+    use_individual = False
+    line_tokens    = []   # resolved line-names or keyword strings
 
     for raw in raw_tokens:
 
-        if raw in _COMBINATOR_TOKENS:
+        if raw in ("AND", "OR"):
             combinator = raw
             continue
 
@@ -625,7 +602,12 @@ def parse_ref_line(ref_line_method, line_names):
             use_window = True
             continue
 
-        if raw in _KEYWORD_TOKENS:
+        if raw == "individual":
+            use_individual = True
+            line_tokens.append("individual")
+            continue
+
+        if raw in ("first", "all"):
             line_tokens.append(raw)
             continue
 
@@ -634,33 +616,28 @@ def parse_ref_line(ref_line_method, line_names):
             n = int(raw)
         except ValueError:
             n = None
-
         if n is not None:
             if n < 1:
                 raise ValueError(
-                    f"parse_ref_line: integer token must be ≥ 1, got '{raw}'."
+                    f"parse_ref_line: integer token must be \u2265 1, got '{raw}'."
                 )
-            line_tokens.append(raw)
+            line_tokens.append(raw)   # store as string for uniform handling
             continue
 
         # Named line from the cube list?
-        if raw in line_names:
-            line_tokens.append(raw)
+        if raw in upper_to_orig:
+            line_tokens.append(upper_to_orig[raw])   # preserve original case
             continue
 
-        # Nothing matched — hard error
+        # Nothing matched
         raise ValueError(
             f"parse_ref_line: unrecognised token '{raw}'. "
             f"Expected one of: AND, OR, input, window, first, all, individual, "
-            f"a positive integer, or a line name from the cube list {line_names}."
+            f"a positive integer, or a line name from {line_names}."
         )
 
-    # ----------------------------------------------------------------
-    # Step 3: resolve the line-selection tokens
-    # ----------------------------------------------------------------
-    # Validate: at most ONE line-selection mode is allowed.
-    # (multiple named lines are fine; mixing FIRST with a line name is not)
-    keyword_found = [t for t in line_tokens if t in _KEYWORD_TOKENS]
+    # --- resolve line-selection tokens → mask_lines ---------------------
+    keyword_found = [t for t in line_tokens if t in ("first", "all", "individual")]
     named_found   = [t for t in line_tokens if t in line_names]
     int_found     = []
     for t in line_tokens:
@@ -669,22 +646,22 @@ def parse_ref_line(ref_line_method, line_names):
         except ValueError:
             pass
 
-    # Check for conflicting selection modes
     n_modes = (
-        (1 if "individual" in keyword_found else 0)
-        + (1 if "all" in keyword_found else 0)
+        (1 if use_individual else 0)
+        + (1 if "all"   in keyword_found else 0)
         + (1 if "first" in keyword_found else 0)
         + (1 if int_found else 0)
         + (1 if named_found else 0)
     )
     if n_modes > 1:
         raise ValueError(
-            f"parse_ref_line: conflicting line-selection tokens in '{ref_line_method}'. "
-            f"Provide exactly one of: first, all, individual, an integer, or line name(s)."
+            f"parse_ref_line: conflicting line-selection tokens in "
+            f"'{ref_line_method}'. Provide exactly one of: first, all, "
+            f"individual, an integer, or line name(s)."
         )
 
     if not line_tokens:
-        # Only external tokens provided — no S/N mask
+        # Only external-mask tokens — no S/N mask
         if not use_input and not use_window:
             raise ValueError(
                 f"parse_ref_line: no valid token found in '{ref_line_method}'. "
@@ -693,28 +670,20 @@ def parse_ref_line(ref_line_method, line_names):
             )
         mask_lines = []
 
-    elif "individual" in line_tokens:
-        mask_lines = None
+    elif use_individual:
+        mask_lines = list(line_names)   # all lines get their own mask
 
-    elif "all" in line_tokens:
-        mask_lines = line_names
+    elif "all" in keyword_found:
+        mask_lines = list(line_names)
 
-    elif "first" in line_tokens:
+    elif "first" in keyword_found:
         mask_lines = [line_names[0]]
 
     elif int_found:
-        n = int_found[0]
-        n = max(1, min(n, len(line_names)))
-        mask_lines = line_names[:n]
+        n = max(1, min(int_found[0], len(line_names)))
+        mask_lines = list(line_names[:n])
 
     else:
-        # Named lines
-        mask_lines = named_found   # already validated above
+        mask_lines = named_found   # original case preserved
 
-    print(f"parse_ref_line: mask_lines={mask_lines}, \
-          use_input={use_input}, \
-          use_window={use_window}, \
-          combinator={combinator}"
-          )
-
-    return mask_lines, use_input, use_window, combinator
+    return mask_lines, use_individual, use_input, use_window, combinator


### PR DESCRIPTION
New feature to use ref_line variable to arbitrarily combine signal-based and external masks.
HFS are now processed in a logical way such that all combined and external masks are shifted to the HFS frequencies for the respective line. For the individual line masking, the signal-based masked is not shuffled to the HFS frequencies because the masks itself should already capture the HFS transitions.